### PR TITLE
feat: `CSSInliner.inline_to` associated method that writes the inlined document to a generic writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `CSSInliner` and customization options. [#9](https://github.com/Stranger6667/css-inline/issues/9)
 - Option to remove "style" tags. [#11](https://github.com/Stranger6667/css-inline/issues/11)
 - `CSSInliner::compact()` constructor for producing smaller HTML output.
+- `CSSInliner.inline_to` that writes the output to a generic writer. [#24](https://github.com/Stranger6667/css-inline/issues/24)
 
 ### Changed
 


### PR DESCRIPTION
Resolves #24 