### PR TITLE
chore: Add `Result` type alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Remove debug symbols from the release build
+
 ### Performance
 
 - Reduce the number of `String` allocations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Performance
 
 - Reduce the number of `String` allocations.
+- Avoid `BTreeMap::insert` when `style` attribute already exists
 
 ## [0.3.1] - 2020-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Performance
+
+- Reduce the number of `String` allocations.
+
 ## [0.3.1] - 2020-06-25
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,3 @@ criterion = ">= 0.1"
 [[bench]]
 name = "inliner"
 harness = false
-
-[profile.release]
-debug = true

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Remove debug symbols from the release build
 
+### Performance
+
+- Various performance improvements
+
 ## [0.2.0] - 2020-06-25
 
 ### Added

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Remove debug symbols from the release build
+
 ## [0.2.0] - 2020-06-25
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,7 +279,7 @@ fn process_css(document: &NodeRef, css: &str) -> Result<()> {
                             merge_styles(existing_style, &rule.declarations)?
                         } else {
                             let mut final_styles = String::with_capacity(32);
-                            for (name, value) in rule.declarations.iter() {
+                            for (name, value) in &rule.declarations {
                                 final_styles.push_str(name);
                                 final_styles.push(':');
                                 final_styles.push_str(value);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,8 +275,8 @@ fn process_css(document: &NodeRef, css: &str) -> Result<()> {
                     // It can be borrowed if the current selector matches <link> tag, that is
                     // already borrowed in `inline_to`. We can ignore such matches
                     if let Ok(mut attributes) = matching_element.attributes.try_borrow_mut() {
-                        let style = if let Some(existing_style) = attributes.get("style") {
-                            merge_styles(existing_style, &rule.declarations)?
+                        if let Some(existing_style) = attributes.get_mut("style") {
+                            *existing_style = merge_styles(existing_style, &rule.declarations)?
                         } else {
                             let mut final_styles = String::with_capacity(32);
                             for (name, value) in &rule.declarations {
@@ -285,9 +285,8 @@ fn process_css(document: &NodeRef, css: &str) -> Result<()> {
                                 final_styles.push_str(value);
                                 final_styles.push(';');
                             }
-                            final_styles
+                            attributes.insert("style", final_styles);
                         };
-                        attributes.insert("style", style);
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,10 +278,14 @@ fn process_css(document: &NodeRef, css: &str) -> Result<()> {
                         let style = if let Some(existing_style) = attributes.get("style") {
                             merge_styles(existing_style, &rule.declarations)?
                         } else {
-                            rule.declarations
-                                .iter()
-                                .map(|&(ref key, value)| format!("{}:{};", key, value))
-                                .collect()
+                            let mut final_styles = String::with_capacity(32);
+                            for (name, value) in rule.declarations.iter() {
+                                final_styles.push_str(name);
+                                final_styles.push(':');
+                                final_styles.push_str(value);
+                                final_styles.push(';');
+                            }
+                            final_styles
                         };
                         attributes.insert("style", style);
                     }
@@ -332,8 +336,12 @@ fn merge_styles(existing_style: &str, new_styles: &[parser::Declaration]) -> Res
         styles.insert(property.to_string(), value);
     }
     // Create a new declarations list
-    Ok(styles
-        .into_iter()
-        .map(|(key, value)| format!("{}:{};", key, value))
-        .collect::<String>())
+    let mut final_styles = String::with_capacity(32);
+    for (name, value) in &styles {
+        final_styles.push_str(name.as_str());
+        final_styles.push(':');
+        final_styles.push_str(value);
+        final_styles.push(';');
+    }
+    Ok(final_styles)
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,8 +1,25 @@
+use kuchiki::Selectors;
+
 pub struct CSSRuleListParser;
 pub(crate) struct CSSDeclarationListParser;
 
 pub type Declaration<'i> = (cssparser::CowRcStr<'i>, &'i str);
 pub type QualifiedRule<'i> = (&'i str, Vec<Declaration<'i>>);
+
+#[derive(Debug)]
+pub(crate) struct Rule<'i> {
+    pub(crate) selectors: Selectors,
+    pub(crate) declarations: Vec<Declaration<'i>>,
+}
+
+impl<'i> Rule<'i> {
+    pub fn new(selectors: &str, declarations: Vec<Declaration<'i>>) -> Result<Rule<'i>, ()> {
+        Ok(Rule {
+            selectors: Selectors::compile(selectors)?,
+            declarations,
+        })
+    }
+}
 
 fn exhaust<'i>(input: &mut cssparser::Parser<'i, '_>) -> &'i str {
     let start = input.position();


### PR DESCRIPTION
Performance improvements are reproducible:

```
     Running target/release/deps/inliner-a36131fd00d35cf8
simple HTML             time:   [24.598 us 24.631 us 24.668 us]                         
                        change: [-2.7645% -2.3793% -1.8922%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe

merging styles          time:   [30.752 us 30.806 us 30.862 us]                            
                        change: [-5.2063% -4.4835% -4.0004%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
```