### PR TITLE
chore: Use stable Rust for tox tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,8 +129,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          # TODO: Using nightly makes `cargo build` fail (at least it happens with 2020-06-12 nightly compiler)
-          toolchain: nightly-2020-06-11
+          toolchain: stable
           override: true
 
       - name: Run ${{ matrix.python }} tox job


### PR DESCRIPTION
Resolves #57 