### PR TITLE
perf: Avoid parsing of rule declarations when it is not needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 
 ### Performance
 
-- Avoid string allocation in `get_full_url`
+- Avoid string allocation in `get_full_url`.
+- Parse declarations only when they are merged, otherwise copy as they are.
 
 ## [0.4.0] - 2020-07-13
 

--- a/benches/inliner.rs
+++ b/benches/inliner.rs
@@ -25,6 +25,45 @@ fn simple(c: &mut Criterion) {
     c.bench_function("simple HTML", |b| b.iter(|| inline(html).unwrap()));
 }
 
+fn many_matched_tags(c: &mut Criterion) {
+    let html = black_box(
+        r#"<html>
+<head>
+    <title>Test</title>
+    <style>
+        h1 { color:blue; }
+    </style>
+</head>
+<body>
+    <h1>Big Text</h1>
+    <h1>Big Text</h1>
+    <h1>Big Text</h1>
+    <h1>Big Text</h1>
+    <h1>Big Text</h1>
+    <h1>Big Text</h1>
+    <h1>Big Text</h1>
+    <h1>Big Text</h1>
+    <h1>Big Text</h1>
+    <h1>Big Text</h1>
+    <h1>Big Text</h1>
+    <h1>Big Text</h1>
+    <h1>Big Text</h1>
+    <h1>Big Text</h1>
+    <h1>Big Text</h1>
+    <h1>Big Text</h1>
+    <h1>Big Text</h1>
+    <h1>Big Text</h1>
+    <h1>Big Text</h1>
+    <h1>Big Text</h1>
+    <h1>Big Text</h1>
+</body>
+</html>"#,
+    );
+    c.bench_function("many matched tags HTML", |b| {
+        b.iter(|| inline(html).unwrap())
+    });
+}
+
 fn merging(c: &mut Criterion) {
     let html = black_box(
         r#"<html>
@@ -156,5 +195,5 @@ BEGIN FOOTER
     c.bench_function("big email", |b| b.iter(|| inline(html).unwrap()));
 }
 
-criterion_group!(benches, simple, merging, big_email);
+criterion_group!(benches, simple, many_matched_tags, merging, big_email);
 criterion_main!(benches);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,7 +2,7 @@ pub(crate) struct CSSRuleListParser;
 pub(crate) struct CSSDeclarationListParser;
 
 pub(crate) type Declaration<'i> = (cssparser::CowRcStr<'i>, &'i str);
-pub(crate) type QualifiedRule<'i> = (&'i str, Vec<Declaration<'i>>);
+pub(crate) type QualifiedRule<'i> = (&'i str, &'i str);
 
 fn exhaust<'i>(input: &mut cssparser::Parser<'i, '_>) -> &'i str {
     let start = input.position();
@@ -33,16 +33,7 @@ impl<'i> cssparser::QualifiedRuleParser<'i> for CSSRuleListParser {
         input: &mut cssparser::Parser<'i, 't>,
     ) -> Result<Self::QualifiedRule, cssparser::ParseError<'i, Self::Error>> {
         // Parse list of declarations
-        let parser = cssparser::DeclarationListParser::new(input, CSSDeclarationListParser);
-        let mut declarations = Vec::with_capacity(8);
-
-        for item in parser {
-            if let Ok(declaration) = item {
-                declarations.push(declaration);
-            }
-        }
-
-        Ok((prelude, declarations))
+        Ok((prelude, exhaust(input)))
     }
 }
 


### PR DESCRIPTION
TODO:

- [ ] Fix tests. now the output may have more whitespace character;
- [ ] Improve the new benchmark. Add styles to 50% of h1 tags
- [ ] Check why the parser that parser only rule name is slower than the current one; in theory, it should do less work