### PR TITLE
Dedup stylesheet href

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,12 +296,12 @@ impl<'a> CSSInliner<'a> {
                         .as_ref()
                         .unwrap()
                         .to_string()
-                        .clone()
+                        
                 })
                 .collect::<Vec<String>>();
             links.sort();
             links.dedup();
-            for href in links.iter() {
+            for href in &links {
                 let url = self.get_full_url(href);
                 let css = self.load_external(url.as_ref())?;
                 process_css(&document, css.as_str())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,17 +294,18 @@ impl<'a> CSSInliner<'a> {
                         .borrow()
                         .get("href")
                         .as_ref()
-                        .unwrap()
+                        .unwrap_or_else(|| &"")
                         .to_string()
-                        
                 })
                 .collect::<Vec<String>>();
             links.sort();
             links.dedup();
             for href in &links {
-                let url = self.get_full_url(href);
-                let css = self.load_external(url.as_ref())?;
-                process_css(&document, css.as_str())?;
+                if !href.is_empty() {
+                    let url = self.get_full_url(href);
+                    let css = self.load_external(url.as_ref())?;
+                    process_css(&document, css.as_str())?;
+                }
             }
         }
         if let Some(extra_css) = &self.options.extra_css {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,15 +285,26 @@ impl<'a> CSSInliner<'a> {
             }
         }
         if self.options.load_remote_stylesheets {
-            for link_tag in document
+            let mut links = document
                 .select("link[rel~=stylesheet]")
                 .map_err(|_| error::InlineError::ParseError(Cow::from("Unknown error")))?
-            {
-                if let Some(href) = link_tag.attributes.borrow().get("href") {
-                    let url = self.get_full_url(href);
-                    let css = self.load_external(url.as_ref())?;
-                    process_css(&document, css.as_str())?;
-                }
+                .map(|link_tag| {
+                    link_tag
+                        .attributes
+                        .borrow()
+                        .get("href")
+                        .as_ref()
+                        .unwrap()
+                        .to_string()
+                        .clone()
+                })
+                .collect::<Vec<String>>();
+            links.sort();
+            links.dedup();
+            for href in links.iter() {
+                let url = self.get_full_url(href);
+                let css = self.load_external(url.as_ref())?;
+                process_css(&document, css.as_str())?;
             }
         }
         if let Some(extra_css) = &self.options.extra_css {


### PR DESCRIPTION
Dearest Maintainer,

First thank you for your work on this project. I am comparing this to
the Roadie gem for ruby. It inlines css into html emails. I have a
really fun email that keeps including a script tag. The same dup script
tag. I have updated your code to dedup the hrefs you are loading.

Thanks again. Your command line tool takes 3.1 seconds where the
Roadie gem takes about 2 minutes.

Dictated but not reviewed,
Becker