### PR TITLE
fix: Ignored `style` tags when the document contains multiple of them and the `remove_style_tags: true` config option is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Ignored `style` tags when the document contains multiple of them and the `remove_style_tags: true` config option is used. [#110](https://github.com/Stranger6667/css-inline/issues/110)
+
 ## [0.7.0] - 2021-06-09
 
 ### Fixed

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Ignored `style` tags when the document contains multiple of them and the `remove_style_tags: true` config option is used. [#110](https://github.com/Stranger6667/css-inline/issues/110)
+
 ## [0.7.0] - 2021-06-09
 
 ### Fixed

--- a/bindings/wasm/CHANGELOG.md
+++ b/bindings/wasm/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Ignored `style` tags when the document contains multiple of them and the `remove_style_tags: true` config option is used. [#110](https://github.com/Stranger6667/css-inline/issues/110)
+
 ## [0.7.0] - 2021-06-09
 
 ### Fixed

--- a/css-inline/benches/inliner.rs
+++ b/css-inline/benches/inliner.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use css_inline::{inline, InlineError};
+use css_inline::{inline, CSSInliner, InlineError};
 
 fn simple(c: &mut Criterion) {
     let html = black_box(
@@ -52,6 +52,36 @@ fn merging(c: &mut Criterion) {
 </html>"#,
     );
     c.bench_function("merging styles", |b| b.iter(|| inline(html).unwrap()));
+}
+
+fn removing_tags(c: &mut Criterion) {
+    let html = black_box(
+        r#"<html>
+<head>
+<style>
+h1 {
+    text-decoration: none;
+}
+</style>
+<style>
+.test-class {
+        color: #ffffff;
+}
+a {
+        color: #17bebb;
+}
+</style>
+</head>
+<body>
+<a class="test-class" href="https://example.com">Test</a>
+<h1>Test</h1>
+</body>
+</html>"#,
+    );
+    let inliner = CSSInliner::compact();
+    c.bench_function("removing tags", |b| {
+        b.iter(|| inliner.inline(html).unwrap())
+    });
 }
 
 fn big_email(c: &mut Criterion) {
@@ -161,5 +191,12 @@ BEGIN FOOTER
     c.bench_function("big email", |b| b.iter(|| inline(html).unwrap()));
 }
 
-criterion_group!(benches, simple, merging, big_email, error_formatting);
+criterion_group!(
+    benches,
+    simple,
+    merging,
+    removing_tags,
+    big_email,
+    error_formatting
+);
 criterion_main!(benches);

--- a/css-inline/tests/test_inlining.rs
+++ b/css-inline/tests/test_inlining.rs
@@ -128,6 +128,93 @@ fn remove_style_tag() {
 }
 
 #[test]
+fn remove_multiple_style_tags() {
+    let html = r#"
+<html>
+<head>
+<style>
+h1 {
+    text-decoration: none;
+}
+</style>
+<style>
+.test-class {
+        color: #ffffff;
+}
+a {
+        color: #17bebb;
+}
+</style>
+</head>
+<body>
+<a class="test-class" href="https://example.com">Test</a>
+<h1>Test</h1>
+</body>
+</html>
+    "#;
+    let inliner = CSSInliner::compact();
+    let result = inliner.inline(&html).unwrap();
+    assert_eq!(
+        result,
+        r#"<html><head>
+
+
+</head>
+<body>
+<a class="test-class" href="https://example.com" style="color: #ffffff;">Test</a>
+<h1 style="text-decoration: none;">Test</h1>
+
+
+    </body></html>"#
+    )
+}
+
+#[test]
+fn remove_multiple_style_tags_without_inlining() {
+    let html = r#"
+<html>
+<head>
+<style>
+h1 {
+    text-decoration: none;
+}
+</style>
+<style>
+.test-class {
+        color: #ffffff;
+}
+a {
+        color: #17bebb;
+}
+</style>
+</head>
+<body>
+<a class="test-class" href="https://example.com">Test</a>
+<h1>Test</h1>
+</body>
+</html>
+    "#;
+    let inliner = CSSInliner::options()
+        .remove_style_tags(true)
+        .inline_style_tags(false)
+        .build();
+    let result = inliner.inline(&html).unwrap();
+    assert_eq!(
+        result,
+        r#"<html><head>
+
+
+</head>
+<body>
+<a class="test-class" href="https://example.com">Test</a>
+<h1>Test</h1>
+
+
+    </body></html>"#
+    )
+}
+
+#[test]
 fn do_not_process_style_tag() {
     let html = html!("h1 {background-color: blue;}", "<h1>Hello world!</h1>");
     let options = InlineOptions {


### PR DESCRIPTION
Fixes #110