### PR TITLE
fix: css-inline does not follow cascade/specificity rules

### DIFF
--- a/css-inline/Cargo.toml
+++ b/css-inline/Cargo.toml
@@ -25,7 +25,7 @@ memchr = "2.4"
 attohttpc = { version = "0", default-features = false, features = ["compress", "tls-rustls"] }
 url = "2"
 smallvec = "1"
-ahash = "0.7"
+indexmap = "1.8.1"
 pico-args = { version = "0.3", optional = true }
 rayon = { version = "1.5", optional = true }
 

--- a/css-inline/tests/test_inlining.rs
+++ b/css-inline/tests/test_inlining.rs
@@ -21,6 +21,22 @@ p.footer { font-size: 1px}"#,
 }
 
 #[test]
+fn maintain_rules_order() {
+    assert_inlined!(
+        style = r#"
+.test-class {
+    padding-top: 15px;
+    padding: 10px;
+    padding-left: 12px;
+}"#,
+        body = r#"<a class="test-class" href="https://example.com">Test</a>"#,
+        // Then the final style should come from the more specific selector
+        expected =
+            r#"<a class="test-class" href="https://example.com" style="padding-top: 15px;padding: 10px;padding-left: 12px;">Test</a>"#
+    )
+}
+
+#[test]
 fn overlap_styles() {
     // When two selectors match the same element
     assert_inlined!(


### PR DESCRIPTION
Resolves [#142](https://github.com/Stranger6667/css-inline/issues/142)

Please be easy on me as this is literally the first time I see Rust.
Seems to works well in my project and passes added test and visual inspection of more complex use cases.