### PR TITLE
feat: Make loading from local files be gated behind a feature as well.

### DIFF
--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -17,7 +17,7 @@ built = { version = "0.5", features = ["chrono"] }
 path = "../../css-inline"
 version = "*"
 default-features = false
-features = ["http"]
+features = ["http", "file"]
 
 [dependencies]
 url = "2"

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -20,7 +20,7 @@ crate-type = ["cdylib"]
 path = "../../css-inline"
 version = "*"
 default-features = false
-features = ["http"]
+features = ["http", "file"]
 
 [dependencies]
 url = "2"

--- a/css-inline/Cargo.toml
+++ b/css-inline/Cargo.toml
@@ -15,9 +15,10 @@ categories = ["web-programming"]
 name = "css-inline"
 
 [features]
-default = ["cli", "http"]
+default = ["cli", "http", "file"]
 cli = ["pico-args", "rayon"]
 http = ["attohttpc"]
+file = []
 
 [dependencies]
 cssparser = "0.29"


### PR DESCRIPTION
The file loading machinery in `std` is also pretty large--it adds about 500 kB (or about 100 kB compressed) of file size. Like with loading external URLs, this functionality can be unneeded in some applications (such as with wasm binaries, which typically don't have file system access). Allowing external file loading to be disabled avoids incurring this overhead.

Note that I did add `file` as a feature for the wasm bindings. I'm not actually sure if this makes sense (I don't know if wasm binaries can read from disk--if not then I can remove the feature).