### PR TITLE
chore: Update CLI behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- `--output-filename-prefix` CLI option to control the output files prefix.
+
+### Changed
+
+- Return `1` exit code if any of the input files were not processed successfully via CLI.
+
 ## [0.8.4] - 2022-11-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ OPTIONS:
 
     --extra-css
         Additional CSS to inline.
+
+    --output-filename-prefix
+        Custom prefix for output files. Defaults to `inlined.`.
 ```
 
 ## Extra materials

--- a/css-inline/Cargo.toml
+++ b/css-inline/Cargo.toml
@@ -32,6 +32,7 @@ pico-args = { version = "0.3", optional = true }
 rayon = { version = "1.5", optional = true }
 
 [dev-dependencies]
+assert_cmd = "2.0.6"
 criterion = ">= 0.1"
 
 [[bench]]

--- a/css-inline/tests/example.html
+++ b/css-inline/tests/example.html
@@ -1,0 +1,23 @@
+<html>
+<head>
+    <link href="external.css" rel="stylesheet" type="text/css">
+    <style>
+        h1 {
+            text-decoration: none;
+        }
+    </style>
+    <style>
+        .test-class {
+            color: #ffffff;
+        }
+
+        a {
+            color: #17bebb;
+        }
+    </style>
+</head>
+<body>
+<a class="test-class" href="https://example.com">Test</a>
+<h1>Test</h1>
+</body>
+</html>

--- a/css-inline/tests/test_cli.rs
+++ b/css-inline/tests/test_cli.rs
@@ -1,0 +1,57 @@
+use assert_cmd::Command;
+use std::fs;
+
+#[test]
+fn success() {
+    let mut cmd = Command::cargo_bin("css-inline").unwrap();
+    cmd.arg("tests/example.html")
+        .assert()
+        .success()
+        .stdout("tests/example.html: SUCCESS\n");
+    let content = fs::read_to_string("tests/inlined.example.html").unwrap();
+    assert_eq!(
+        content,
+        "<html><head>\n    \
+        <link href=\"external.css\" rel=\"stylesheet\" type=\"text/css\">\n    \
+        <style>\n        h1 {\n            text-decoration: none;\n        }\n    </style>\n    \
+        <style>\n        .test-class {\n            color: #ffffff;\n        }\n\n        a {\n            color: #17bebb;\n        }\n    </style>\n\
+        </head>\n\
+        <body>\n\
+        <a class=\"test-class\" href=\"https://example.com\" style=\"color: #ffffff;\">Test</a>\n\
+        <h1 style=\"text-decoration: none;\">Test</h1>\n\n\n\
+        </body></html>"
+    )
+}
+
+#[test]
+fn remove_style_tags() {
+    let mut cmd = Command::cargo_bin("css-inline").unwrap();
+    cmd.arg("tests/example.html")
+        .arg("--remove-style-tags")
+        .arg("--output-filename-prefix=remove-style-tags.")
+        .assert()
+        .success()
+        .stdout("tests/example.html: SUCCESS\n");
+    let content = fs::read_to_string("tests/remove-style-tags.example.html").unwrap();
+    assert_eq!(
+        content,
+        "<html><head>\n    \
+        <link href=\"external.css\" rel=\"stylesheet\" type=\"text/css\">\n    \
+        \n    \
+        \n\
+        </head>\n\
+        <body>\n\
+        <a class=\"test-class\" href=\"https://example.com\" style=\"color: #ffffff;\">Test</a>\n\
+        <h1 style=\"text-decoration: none;\">Test</h1>\n\n\n\
+        </body></html>"
+    )
+}
+
+#[test]
+fn not_found() {
+    let mut cmd = Command::cargo_bin("css-inline").unwrap();
+    let assert = cmd.arg("unknown.html").assert();
+    assert
+        .failure()
+        .stdout("unknown.html: FAILURE (No such file or directory (os error 2))\n");
+}


### PR DESCRIPTION
- `--output-filename-prefix` option
- Return `1` exit code on errors