### PR TITLE
chore: Replace `kuchiki` with an in-house HTML tree representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## [Unreleased]
 
-### Changed
+### Internal
 
-- Replace `kuchiki` with an in-house HTML tree representation.
+- Replaced the `kuchiki` crate with our custom-built HTML tree representation. [#176](https://github.com/Stranger6667/css-inline/issues/176)
 
 ### Performance
 
-- ???
+- 15-30% average performance improvement due switch from `kuchiki` to a custom-built HTML tree representation.
 
 ## [0.8.5] - 2022-11-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Replace `kuchiki` with an in-house HTML tree representation.
+
+### Performance
+
+- ???
+
 ## [0.8.5] - 2022-11-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ This attribute also allows you to skip `link` and `style` tags:
 
 ## Standards support & restrictions
 
-`css-inline` is built on top of [kuchiki](https://crates.io/crates/kuchiki) and [cssparser](https://crates.io/crates/cssparser) and relies on their behavior for HTML / CSS parsing and serialization.
+`css-inline` is built on top of [cssparser](https://crates.io/crates/cssparser) and relies on its behavior for CSS parsing.
 Notably:
 
 - Only HTML 5, XHTML is not supported;

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Performance
+
+- 15-30% average performance improvement due switch from `kuchiki` to a custom-built HTML tree representation.
+
 ## [0.8.7] - 2023-01-30
 
 ### Added

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -30,7 +30,7 @@ a Rust compiler to build this package from source. The minimum supported Rust ve
 
 ## Usage
 
-To inline CSS in a HTML document:
+To inline CSS in an HTML document:
 
 ```python
 import css_inline
@@ -118,7 +118,7 @@ inliner.inline("...")
 
 ## Standards support & restrictions
 
-`css-inline` is built on top of [kuchiki](https://crates.io/crates/kuchiki) and [cssparser](https://crates.io/crates/cssparser) and relies on their behavior for HTML / CSS parsing and serialization.
+`css-inline` is built on top of [cssparser](https://crates.io/crates/cssparser) and relies on its behavior for CSS parsing.
 Notably:
 
 - Only HTML 5, XHTML is not supported;

--- a/bindings/wasm/CHANGELOG.md
+++ b/bindings/wasm/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Performance
+
+- 15-30% average performance improvement due switch from `kuchiki` to a custom-built HTML tree representation.
+
 ## [0.8.4] - 2022-11-10
 
 ### Added

--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -74,7 +74,7 @@ This attribute also allows you to skip `link` and `style` tags:
 
 ## Standards support & restrictions
 
-`css-inline` is built on top of [kuchiki](https://crates.io/crates/kuchiki) and [cssparser](https://crates.io/crates/cssparser) and relies on their behavior for HTML / CSS parsing and serialization.
+`css-inline` is built on top of [cssparser](https://crates.io/crates/cssparser) and relies on its behavior for CSS parsing.
 Notably:
 
 - Only HTML 5, XHTML is not supported;

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -67,6 +67,7 @@ struct Options {
     base_url: Option<String>,
     load_remote_stylesheets: bool,
     extra_css: Option<String>,
+    preallocate_node_capacity: Option<usize>,
 }
 
 impl Default for Options {
@@ -77,6 +78,7 @@ impl Default for Options {
             base_url: None,
             load_remote_stylesheets: true,
             extra_css: None,
+            preallocate_node_capacity: None,
         }
     }
 }
@@ -99,6 +101,9 @@ impl TryFrom<Options> for rust_inline::InlineOptions<'_> {
             base_url: parse_url(value.base_url)?,
             load_remote_stylesheets: value.load_remote_stylesheets,
             extra_css: value.extra_css.map(Cow::Owned),
+            preallocate_node_capacity: value
+                .preallocate_node_capacity
+                .unwrap_or(rust_inline::DEFAULT_HTML_TREE_CAPACITY),
         })
     }
 }
@@ -123,6 +128,7 @@ interface InlineOptions {
     base_url?: string,
     load_remote_stylesheets?: boolean,
     extra_css?: string,
+    preallocate_node_capacity?: number,
 }
 
 export function inline(html: string, options?: InlineOptions): string;

--- a/css-inline/Cargo.toml
+++ b/css-inline/Cargo.toml
@@ -23,7 +23,7 @@ file = []
 
 [dependencies]
 cssparser = "0.29"
-kuchiki = "0.8"
+html5ever = "0.26.0"
 memchr = "2.4"
 attohttpc = { version = "0", default-features = false, features = ["compress", "tls-rustls"], optional = true }
 url = "2"
@@ -31,10 +31,11 @@ smallvec = "1"
 indexmap = "1.8.1"
 pico-args = { version = "0.3", optional = true }
 rayon = { version = "1.5", optional = true }
+selectors = "0.24.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.6"
-criterion = ">= 0.1"
+criterion = { version = "0.5.1", features = [], default-features = false }
 
 [[bench]]
 name = "inliner"

--- a/css-inline/rustfmt.toml
+++ b/css-inline/rustfmt.toml
@@ -1,0 +1,2 @@
+imports_granularity = "Crate"
+edition = "2021"

--- a/css-inline/src/html/attributes.rs
+++ b/css-inline/src/html/attributes.rs
@@ -1,11 +1,11 @@
 use html5ever::{local_name, namespace_url, ns, tendril::StrTendril, QualName};
-use indexmap::IndexMap;
+use std::collections::HashMap;
 
 /// A collection of HTML attributes.
 #[derive(Debug, PartialEq, Clone)]
 pub(crate) struct Attributes {
     /// Attribute names and their respective values.
-    pub(crate) map: IndexMap<QualName, StrTendril>,
+    pub(crate) map: HashMap<QualName, StrTendril>,
 }
 
 pub(crate) const CSS_INLINE_ATTRIBUTE: &str = "data-css-inline";

--- a/css-inline/src/html/attributes.rs
+++ b/css-inline/src/html/attributes.rs
@@ -1,11 +1,11 @@
 use html5ever::{local_name, namespace_url, ns, tendril::StrTendril, QualName};
-use std::collections::HashMap;
+use indexmap::IndexMap;
 
 /// A collection of HTML attributes.
 #[derive(Debug, PartialEq, Clone)]
 pub(crate) struct Attributes {
     /// Attribute names and their respective values.
-    pub(crate) map: HashMap<QualName, StrTendril>,
+    pub(crate) map: IndexMap<QualName, StrTendril>,
 }
 
 pub(crate) const CSS_INLINE_ATTRIBUTE: &str = "data-css-inline";

--- a/css-inline/src/html/attributes.rs
+++ b/css-inline/src/html/attributes.rs
@@ -1,11 +1,11 @@
 use html5ever::{local_name, namespace_url, ns, tendril::StrTendril, QualName};
-use indexmap::IndexMap;
+use std::collections::BTreeMap;
 
 /// A collection of HTML attributes.
 #[derive(Debug, PartialEq, Clone)]
 pub(crate) struct Attributes {
     /// Attribute names and their respective values.
-    pub(crate) map: IndexMap<QualName, StrTendril>,
+    pub(crate) map: BTreeMap<QualName, StrTendril>,
 }
 
 pub(crate) const CSS_INLINE_ATTRIBUTE: &str = "data-css-inline";

--- a/css-inline/src/html/attributes.rs
+++ b/css-inline/src/html/attributes.rs
@@ -1,0 +1,53 @@
+use html5ever::{local_name, namespace_url, ns, tendril::StrTendril, QualName};
+use indexmap::IndexMap;
+
+/// A collection of HTML attributes.
+#[derive(Debug, PartialEq, Clone)]
+pub(crate) struct Attributes {
+    /// Attribute names and their respective values.
+    pub(crate) map: IndexMap<QualName, StrTendril>,
+}
+
+pub(crate) const CSS_INLINE_ATTRIBUTE: &str = "data-css-inline";
+
+/// Whether an HTML element's attributes contain the 'data-css-inline' flag set to 'ignore'.
+pub(super) fn should_ignore(attributes: &[html5ever::Attribute]) -> bool {
+    attributes
+        .iter()
+        .any(|a| a.name.local == *CSS_INLINE_ATTRIBUTE && a.value == "ignore".into())
+}
+
+impl Attributes {
+    pub(crate) fn new(attributes: Vec<html5ever::Attribute>) -> Attributes {
+        Attributes {
+            map: attributes
+                .into_iter()
+                .map(|attr| (attr.name, attr.value))
+                .collect(),
+        }
+    }
+
+    /// Checks if the attributes map contains a given local name.
+    pub(crate) fn contains(&self, local: html5ever::LocalName) -> bool {
+        self.map.contains_key(&QualName::new(None, ns!(), local))
+    }
+
+    /// Get the value of the attribute with the given local name, if it exists.
+    pub(crate) fn get(&self, local: html5ever::LocalName) -> Option<&str> {
+        self.map
+            .get(&QualName::new(None, ns!(), local))
+            .map(|value| &**value)
+    }
+
+    pub(crate) fn get_style_mut(&mut self) -> Option<&mut StrTendril> {
+        self.map
+            .get_mut(&QualName::new(None, ns!(), local_name!("style")))
+    }
+
+    pub(crate) fn set_style(&mut self, style: String) {
+        self.map.insert(
+            QualName::new(None, ns!(), local_name!("style")),
+            style.into(),
+        );
+    }
+}

--- a/css-inline/src/html/document.rs
+++ b/css-inline/src/html/document.rs
@@ -22,6 +22,7 @@ pub(crate) const DEFAULT_HTML_TREE_CAPACITY: usize = 8;
 ///
 /// Here is an example of how nodes within a `Document` could be arranged:
 ///
+/// ```text
 ///                    Document
 ///                       ↓
 ///                      [N1]
@@ -34,6 +35,7 @@ pub(crate) const DEFAULT_HTML_TREE_CAPACITY: usize = 8;
 ///               /  \          /   \
 ///              /    \        /     \
 ///            [N5]<->[N6]   [N7]<->[N8]
+/// ```
 ///
 /// Each Node within the `Document` is interconnected with its siblings, and has a parent-child
 /// relationship with its descendants.
@@ -159,7 +161,7 @@ impl Document {
     ///   [Child1] <--> [Child2] <--> ...
     ///
     /// After:
-    ///  
+    ///
     ///   [Parent]
     ///      ↓
     ///   [Child1] <--> [Child2] <--> [New] ...

--- a/css-inline/src/html/document.rs
+++ b/css-inline/src/html/document.rs
@@ -251,6 +251,17 @@ impl Document {
         successors(self[node].first_child, |&node| self[node].next_sibling)
     }
 
+    pub(crate) fn node_and_ancestors(&self, node: NodeId) -> impl Iterator<Item = NodeId> + '_ {
+        successors(Some(node), move |&node| self[node].parent)
+    }
+
+    pub(crate) fn next_in_tree_order(&self, node: NodeId) -> Option<NodeId> {
+        self[node].first_child.or_else(|| {
+            self.node_and_ancestors(node)
+                .find_map(|ancestor| self[ancestor].next_sibling)
+        })
+    }
+
     /// Serialize the document to HTML string.
     pub(crate) fn serialize<W: Write>(
         &self,

--- a/css-inline/src/html/document.rs
+++ b/css-inline/src/html/document.rs
@@ -9,9 +9,6 @@ use super::{
 use html5ever::local_name;
 use std::{io, io::Write, iter::successors};
 
-// TODO:
-//   - Make it generic over `NodeId`?
-
 /// The capacity, pre-allocated for HTML nodes during parsing by default.
 pub const DEFAULT_HTML_TREE_CAPACITY: usize = 8;
 
@@ -311,7 +308,17 @@ mod tests {
 
     #[test]
     fn test_collect_styles() {
-        let doc = Document::parse_with_options(b"<html><head><title>Test</title><style>h1 { color:blue; }</style><style>h1 { color:red; }</style><style data-css-inline='ignore'>h1 { color:yellow; }</style></head>", 0);
+        let doc = Document::parse_with_options(
+            r#"
+<head
+  ><title>Test</title>
+  <style>h1 { color:blue; }</style>
+  <style>h1 { color:red; }</style>
+  <style data-css-inline='ignore'>h1 { color:yellow; }</style>
+</head>"#
+                .as_bytes(),
+            0,
+        );
         let styles = doc.styles().collect::<Vec<_>>();
         assert_eq!(styles.len(), 2);
         assert_eq!(styles[0], "h1 { color:blue; }");
@@ -320,7 +327,17 @@ mod tests {
 
     #[test]
     fn test_collect_stylesheets() {
-        let doc = Document::parse_with_options(b"<head><link href='styles1.css' rel='stylesheet' type='text/css'><link href='styles2.css' rel='stylesheet' type='text/css'><link href='styles3.css' rel='stylesheet' type='text/css' data-css-inline='ignore'></head>", 0);
+        let doc = Document::parse_with_options(
+            r#"
+<head>
+  <link href='styles1.css' rel='stylesheet' type='text/css'>
+  <link href='styles2.css' rel='stylesheet' type='text/css'>
+  <link href='' rel='stylesheet' type='text/css'>
+  <link href='styles3.css' rel='stylesheet' type='text/css' data-css-inline='ignore'>
+</head>"#
+                .as_bytes(),
+            0,
+        );
         let links = doc.stylesheets().collect::<Vec<_>>();
         assert_eq!(links.len(), 2);
         assert_eq!(links[0], "styles1.css");

--- a/css-inline/src/html/document.rs
+++ b/css-inline/src/html/document.rs
@@ -12,7 +12,8 @@ use std::{io, io::Write, iter::successors};
 // TODO:
 //   - Make it generic over `NodeId`?
 
-pub(crate) const DEFAULT_HTML_TREE_CAPACITY: usize = 8;
+/// The capacity, pre-allocated for HTML nodes during parsing by default.
+pub const DEFAULT_HTML_TREE_CAPACITY: usize = 8;
 
 /// HTML document representation.
 ///

--- a/css-inline/src/html/document.rs
+++ b/css-inline/src/html/document.rs
@@ -1,0 +1,334 @@
+use super::{
+    element::Element,
+    iter::{select, Select},
+    node::{Node, NodeData, NodeId},
+    parser,
+    selectors::ParseError,
+    serializer::serialize_to,
+};
+use html5ever::local_name;
+use std::{io, io::Write, iter::successors};
+
+// TODO:
+//   - Configure capacity of `Document.nodes` somewhere above the call stack
+//   - Make it generic over `NodeId`?
+
+/// HTML document representation.
+///
+/// A `Document` holds a collection of nodes, with each node representing an HTML element.
+/// Nodes are interconnected to form a tree-like structure, mimicking the HTML DOM tree.
+/// The struct also keeps track of nodes that contain CSS styles or refer to CSS stylesheets.
+///
+/// Here is an example of how nodes within a `Document` could be arranged:
+///
+///                    Document
+///                       ↓
+///                      [N1]
+///                     /   \
+///                    /     \
+///                   /       \
+///                  /         \
+///                 /           \
+///               [N2]<->[N3]<->[N4]
+///               /  \          /   \
+///              /    \        /     \
+///            [N5]<->[N6]   [N7]<->[N8]
+///
+/// Each Node within the `Document` is interconnected with its siblings, and has a parent-child
+/// relationship with its descendants.
+#[derive(Debug)]
+pub(crate) struct Document {
+    nodes: Vec<Node>,
+    /// Ids of `style` nodes.
+    styles: Vec<NodeId>,
+    /// Ids of `link` nodes, specifically those with the `rel` attribute value set as `stylesheet`.
+    /// They represent the locations (URLs) of all linked stylesheet resources in the document.
+    linked_stylesheets: Vec<NodeId>,
+}
+
+impl Document {
+    pub(crate) fn parse(bytes: &[u8]) -> Document {
+        parser::parse(bytes)
+    }
+
+    pub(super) fn new() -> Self {
+        Document::with_capacity(0)
+    }
+
+    pub(super) fn with_capacity(capacity: usize) -> Self {
+        // Dummy node at index 0 so that other indices fit in NonZero
+        let mut nodes = vec![Node::new(NodeData::Document), Node::new(NodeData::Document)];
+        // Usually there are a lot of nodes, hence, reserve some space for them
+        nodes.reserve(capacity);
+        Document {
+            nodes,
+            styles: Vec::new(),
+            linked_stylesheets: Vec::new(),
+        }
+    }
+
+    pub(super) fn as_element(&self, node_id: NodeId) -> Option<Element<'_>> {
+        if let NodeData::Element { element, .. } = &self[node_id].data {
+            Some(Element::new(self, node_id, element))
+        } else {
+            None
+        }
+    }
+
+    /// Add a new `style` element node.
+    pub(super) fn add_style(&mut self, node: NodeId) {
+        self.styles.push(node);
+    }
+
+    /// Iterator over blocks of CSS defined inside `style` tags.
+    pub(crate) fn styles(&self) -> impl Iterator<Item = &str> + '_ {
+        self.styles.iter().filter_map(|node_id| {
+            self[*node_id]
+                .first_child
+                .and_then(|child_id| self[child_id].as_text())
+        })
+    }
+
+    /// Iterate over `href` attribute values of `link[rel~=stylesheet]` tags.
+    pub(crate) fn stylesheets(&self) -> impl Iterator<Item = &str> + '_ {
+        self.linked_stylesheets.iter().filter_map(|node_id| {
+            self[*node_id]
+                .as_element()
+                .and_then(|data| data.attributes.get(local_name!("href")))
+        })
+    }
+
+    /// Add a new linked stylesheet location.
+    pub(super) fn add_linked_stylesheet(&mut self, node: NodeId) {
+        self.linked_stylesheets.push(node);
+    }
+
+    /// Add a new node to the nodes vector, returning its index.
+    pub(super) fn push_node(&mut self, node: NodeData) -> NodeId {
+        let next_index = self.nodes.len();
+        self.nodes.push(Node::new(node));
+        NodeId::new(next_index)
+    }
+
+    /// Detach a node from its siblings and its parent.
+    ///
+    /// Before:
+    ///
+    ///   [Parent]
+    ///     ↓
+    ///    ... [Previous] <--> [Node] <--> [Next] ...
+    ///
+    /// After:
+    ///
+    ///   [Parent]
+    ///     ↓
+    ///    ... [Previous] <--> [Next] ...
+    pub(super) fn detach(&mut self, node: NodeId) {
+        // Save references to the parent and sibling nodes of the node being detached.
+        let (parent, previous_sibling, next_sibling) = {
+            let node = &mut self[node];
+            (
+                node.parent.take(),
+                node.previous_sibling.take(),
+                node.next_sibling.take(),
+            )
+        };
+
+        if let Some(next_sibling) = next_sibling {
+            // Point next sibling one step back to bypass the detached node
+            self[next_sibling].previous_sibling = previous_sibling
+        } else if let Some(parent) = parent {
+            // No next sibling - this node was the last child of the parent node, now the previous
+            // sibling becomes the last child
+            self[parent].last_child = previous_sibling;
+        }
+
+        if let Some(previous_sibling) = previous_sibling {
+            // Point the previous sibling one step forward to bypass the detached node
+            self[previous_sibling].next_sibling = next_sibling;
+        } else if let Some(parent) = parent {
+            // No previous sibling - this node was the first child of the parent node, now the next
+            // sibling becomes the first child
+            self[parent].first_child = next_sibling;
+        }
+    }
+
+    /// Append a new child node to a parent node.
+    ///
+    /// If the parent node already has children. Before:
+    ///
+    ///   [Parent]
+    ///      ↓
+    ///   [Child1] <--> [Child2] <--> ...
+    ///
+    /// After:
+    ///  
+    ///   [Parent]
+    ///      ↓
+    ///   [Child1] <--> [Child2] <--> [New] ...
+    ///
+    /// If the parent node has no children. Before:
+    ///
+    ///   [Parent]
+    ///
+    /// After:
+    ///
+    ///   [Parent]
+    ///     ↓
+    ///   [New]
+    ///
+    /// So, [New} becomes the first child of [Parent].
+    pub(super) fn append(&mut self, parent: NodeId, node: NodeId) {
+        // Detach `node` from its current parent (if any)
+        self.detach(node);
+
+        // Set `node` parent to the specified parent
+        self[node].parent = Some(parent);
+
+        if let Some(last_child) = self[parent].last_child.take() {
+            // Connect `node` with the last child (if any) by adding `node` after it
+            self[node].previous_sibling = Some(last_child);
+            self[last_child].next_sibling = Some(node);
+        } else {
+            // No last child - it becomes the first child
+            self[parent].first_child = Some(node);
+        }
+
+        // Now, `node` is the last child of the new parent
+        self[parent].last_child = Some(node);
+    }
+
+    /// Insert a new node right before a given sibling node.
+    ///
+    /// In general, this method transforms this relationship:
+    ///
+    ///   ... <--> [Previous] <--> [Sibling] <--> [Next] --> ...
+    ///
+    /// into this:
+    ///
+    ///   ... <--> [Previous] <--> [New] <--> [Sibling] <--> [Next] <--> ...
+    ///
+    /// If [Sibling] node is the first child (i.e., no [Previous] exists), the method also updates the parent node:
+    ///
+    /// Before:
+    ///
+    ///   [Parent]
+    ///     ↓
+    ///   [Sibling] <--> [Next] <--> ...
+    ///
+    /// After:
+    ///
+    ///   [Parent]
+    ///     ↓
+    ///   [New] <--> [Sibling] <--> [Next] <--> ...
+    ///
+    /// So, [New] becomes the first child of [Parent].
+    pub(super) fn insert_before(&mut self, sibling: NodeId, node: NodeId) {
+        // Detach `node` from its current parent (if any)
+        self.detach(node);
+
+        // Set `node` parent to `sibling` parent
+        self[node].parent = self[sibling].parent;
+
+        // As it is inserted before, then `next_sibling` should point to `sibling`
+        self[node].next_sibling = Some(sibling);
+
+        if let Some(previous_sibling) = self[sibling].previous_sibling.take() {
+            // Connect `node` with the previous sibling (if any)
+            self[node].previous_sibling = Some(previous_sibling);
+            self[previous_sibling].next_sibling = Some(node);
+        } else if let Some(parent) = self[sibling].parent {
+            // No previous sibling - then it is the first child of its parent, so the parent node
+            // should be updated too
+            self[parent].first_child = Some(node);
+        }
+
+        // Now `node` is the previous sibling of the `sibling` node
+        self[sibling].previous_sibling = Some(node);
+    }
+
+    /// Returns an iterator over the direct children of a node.
+    pub(super) fn children(&self, node: NodeId) -> impl Iterator<Item = NodeId> + '_ {
+        successors(self[node].first_child, |&node| self[node].next_sibling)
+    }
+
+    /// Serialize the document to HTML string.
+    pub(crate) fn serialize<W: Write>(
+        &self,
+        writer: &mut W,
+        skip_style_tags: bool,
+    ) -> io::Result<()> {
+        serialize_to(self, writer, skip_style_tags)
+    }
+
+    /// Filter this node iterator to elements matching the given selectors.
+    pub(crate) fn select<'a, 'b>(
+        &'a self,
+        selectors: &'b str,
+    ) -> Result<Select<'a>, ParseError<'b>> {
+        select(self, selectors)
+    }
+}
+
+impl std::ops::Index<NodeId> for Document {
+    type Output = Node;
+
+    #[inline]
+    fn index(&self, id: NodeId) -> &Node {
+        &self.nodes[id.get()]
+    }
+}
+
+impl std::ops::IndexMut<NodeId> for Document {
+    #[inline]
+    fn index_mut(&mut self, id: NodeId) -> &mut Node {
+        &mut self.nodes[id.get()]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{super::node::ElementData, *};
+    use html5ever::{local_name, namespace_url, ns, QualName};
+
+    fn new_element() -> NodeData {
+        NodeData::Element {
+            element: ElementData::new(QualName::new(None, ns!(), local_name!("span")), vec![]),
+            inlining_ignored: false,
+        }
+    }
+
+    #[test]
+    fn test_insert_before() {
+        let mut doc = Document::new();
+
+        let node1_id = doc.push_node(new_element());
+        let node2_id = doc.push_node(new_element());
+        let new_node_id = doc.push_node(new_element());
+
+        let document_id = NodeId::document_id();
+        doc.append(document_id, node1_id);
+        doc.append(document_id, node2_id);
+
+        doc.insert_before(node2_id, new_node_id);
+
+        assert_eq!(doc[node2_id].previous_sibling, Some(new_node_id));
+        assert_eq!(doc[new_node_id].next_sibling, Some(node2_id));
+    }
+
+    #[test]
+    fn test_append() {
+        let mut doc = Document::new();
+
+        let node1_id = doc.push_node(new_element());
+        let node2_id = doc.push_node(new_element());
+
+        let document_id = NodeId::document_id();
+        doc.append(document_id, node1_id);
+        doc.append(document_id, node2_id);
+
+        assert_eq!(doc[document_id].last_child, Some(node2_id));
+        assert_eq!(doc[node1_id].next_sibling, Some(node2_id));
+        assert_eq!(doc[node2_id].previous_sibling, Some(node1_id));
+    }
+}

--- a/css-inline/src/html/element.rs
+++ b/css-inline/src/html/element.rs
@@ -1,0 +1,264 @@
+use super::{
+    attributes::Attributes,
+    document::Document,
+    node::{ElementData, NodeData, NodeId},
+    selectors::{AttrValue, InlinerSelectors, LocalName, PseudoClass, PseudoElement, Selector},
+};
+use html5ever::{local_name, namespace_url, ns, Namespace, QualName};
+use selectors::{
+    attr::{AttrSelectorOperation, CaseSensitivity, NamespaceConstraint},
+    context::QuirksMode,
+    matching, OpaqueElement,
+};
+
+/// A reference to an element node in a document.
+/// This structure is necessary for accessing and iterating over other nodes in the tree.
+#[derive(Debug, Clone)]
+pub(crate) struct Element<'a> {
+    /// Reference to the original document.
+    pub(crate) document: &'a Document,
+    // TODO: Store `node` instead? to avoid going via `document[node_id]`
+    /// The unique identifier of the node in the document.
+    pub(crate) node_id: NodeId,
+    /// The specific data associated with the element.
+    data: &'a ElementData,
+}
+
+impl<'a> Element<'a> {
+    pub(crate) fn new(
+        document: &'a Document,
+        node_id: NodeId,
+        data: &'a ElementData,
+    ) -> Element<'a> {
+        Element {
+            document,
+            node_id,
+            data,
+        }
+    }
+    /// Qualified name of the element.
+    pub(crate) fn name(&self) -> &QualName {
+        &self.data.name
+    }
+    /// Attributes of the element.
+    pub(crate) fn attributes(&self) -> &Attributes {
+        &self.data.attributes
+    }
+    /// A reference to the element data.
+    pub(crate) fn data(&self) -> &'a ElementData {
+        self.data
+    }
+    /// ID of the parent node of the element, if it exists.
+    pub(crate) fn parent(&self) -> Option<NodeId> {
+        self.document[self.node_id].parent
+    }
+    /// The parent element of the current element, if it exists.
+    /// This function will return `None` if the parent node is not an element.
+    pub(crate) fn parent_element(&self) -> Option<Element<'a>> {
+        self.parent()
+            .and_then(|node_id| self.document.as_element(node_id))
+    }
+    fn previous_sibling_element(&self) -> Option<Element<'a>> {
+        self.document[self.node_id]
+            .previous_sibling
+            .and_then(|node_id| self.document.as_element(node_id))
+    }
+    fn next_sibling_element(&self) -> Option<Element<'a>> {
+        self.document[self.node_id]
+            .next_sibling
+            .and_then(|node_id| self.document.as_element(node_id))
+    }
+    pub(crate) fn matches(&self, selector: &Selector) -> bool {
+        let mut context = matching::MatchingContext::new(
+            matching::MatchingMode::Normal,
+            None,
+            None,
+            QuirksMode::NoQuirks,
+        );
+        matching::matches_selector(
+            selector.inner_value(),
+            0,
+            None,
+            self,
+            &mut context,
+            &mut |_, _| {},
+        )
+    }
+}
+
+static SELECTOR_WHITESPACE: &[char] = &[' ', '\t', '\n', '\r', '\x0C'];
+
+impl<'a> selectors::Element for Element<'a> {
+    type Impl = InlinerSelectors;
+
+    #[inline]
+    fn opaque(&self) -> OpaqueElement {
+        OpaqueElement::new(self.data())
+    }
+
+    #[inline]
+    fn parent_element(&self) -> Option<Self> {
+        self.parent_element()
+    }
+    #[inline]
+    fn parent_node_is_shadow_root(&self) -> bool {
+        false
+    }
+    #[inline]
+    fn containing_shadow_host(&self) -> Option<Self> {
+        None
+    }
+
+    #[inline]
+    fn is_pseudo_element(&self) -> bool {
+        false
+    }
+    #[inline]
+    fn prev_sibling_element(&self) -> Option<Self> {
+        self.previous_sibling_element()
+    }
+    #[inline]
+    fn next_sibling_element(&self) -> Option<Self> {
+        self.next_sibling_element()
+    }
+    #[inline]
+    fn is_html_element_in_html_document(&self) -> bool {
+        self.name().ns == ns!(html)
+    }
+    #[inline]
+    fn has_local_name(&self, name: &LocalName) -> bool {
+        self.name().local == *name
+    }
+
+    #[inline]
+    fn has_namespace(&self, namespace: &Namespace) -> bool {
+        self.name().ns == *namespace
+    }
+
+    #[inline]
+    fn is_same_type(&self, other: &Self) -> bool {
+        self.name() == other.name()
+    }
+    #[inline]
+    fn attr_matches(
+        &self,
+        ns: &NamespaceConstraint<&Namespace>,
+        local_name: &LocalName,
+        operation: &AttrSelectorOperation<&AttrValue>,
+    ) -> bool {
+        let attrs = self.attributes();
+        match *ns {
+            NamespaceConstraint::Any => attrs
+                .map
+                .iter()
+                .any(|(name, value)| name.local == *local_name && operation.eval_str(value)),
+            NamespaceConstraint::Specific(ns_url) => attrs
+                .map
+                .get(&QualName::new(
+                    None,
+                    ns_url.clone(),
+                    local_name.clone().into_inner(),
+                ))
+                .map_or(false, |value| operation.eval_str(value)),
+        }
+    }
+
+    fn match_non_ts_pseudo_class<F>(
+        &self,
+        pseudo: &PseudoClass,
+        _context: &mut matching::MatchingContext<'_, InlinerSelectors>,
+        _flags_setter: &mut F,
+    ) -> bool
+    where
+        F: FnMut(&Self, matching::ElementSelectorFlags),
+    {
+        use self::PseudoClass::*;
+        match *pseudo {
+            Active | Focus | Hover | Enabled | Disabled | Checked | Indeterminate | Visited => {
+                false
+            }
+            AnyLink | Link => {
+                self.name().ns == ns!(html)
+                    && matches!(
+                        self.name().local,
+                        local_name!("a") | local_name!("area") | local_name!("link")
+                    )
+                    && self.attributes().contains(local_name!("href"))
+            }
+        }
+    }
+
+    fn match_pseudo_element(
+        &self,
+        pseudo: &PseudoElement,
+        _context: &mut matching::MatchingContext<'_, InlinerSelectors>,
+    ) -> bool {
+        match *pseudo {}
+    }
+
+    #[inline]
+    fn is_link(&self) -> bool {
+        self.name().ns == ns!(html)
+            && matches!(
+                self.name().local,
+                local_name!("a") | local_name!("area") | local_name!("link")
+            )
+            && self.attributes().contains(local_name!("href"))
+    }
+
+    #[inline]
+    fn is_html_slot_element(&self) -> bool {
+        false
+    }
+
+    #[inline]
+    fn has_id(&self, id: &LocalName, case_sensitivity: CaseSensitivity) -> bool {
+        self.attributes()
+            .get(local_name!("id"))
+            .map_or(false, |id_attr| {
+                case_sensitivity.eq(id.as_bytes(), id_attr.as_bytes())
+            })
+    }
+
+    #[inline]
+    fn has_class(&self, name: &LocalName, case_sensitivity: CaseSensitivity) -> bool {
+        let name = name.as_bytes();
+        !name.is_empty()
+            && if let Some(class_attr) = self.attributes().get(local_name!("class")) {
+                class_attr
+                    .split(SELECTOR_WHITESPACE)
+                    .any(|class| case_sensitivity.eq(class.as_bytes(), name))
+            } else {
+                false
+            }
+    }
+
+    #[inline]
+    fn imported_part(&self, _: &LocalName) -> Option<LocalName> {
+        None
+    }
+
+    #[inline]
+    fn is_part(&self, _name: &LocalName) -> bool {
+        false
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.document
+            .children(self.node_id)
+            .all(|child| match &self.document[child].data {
+                NodeData::Element { .. } => false,
+                NodeData::Text { text: content } => content.is_empty(),
+                _ => true,
+            })
+    }
+
+    #[inline]
+    fn is_root(&self) -> bool {
+        match self.parent() {
+            None => false,
+            Some(node_id) => matches!(self.document[node_id].data, NodeData::Document),
+        }
+    }
+}

--- a/css-inline/src/html/element.rs
+++ b/css-inline/src/html/element.rs
@@ -17,7 +17,6 @@ use selectors::{
 pub(crate) struct Element<'a> {
     /// Reference to the original document.
     pub(crate) document: &'a Document,
-    // TODO: Store `node` instead? to avoid going via `document[node_id]`
     /// The unique identifier of the node in the document.
     pub(crate) node_id: NodeId,
     /// The specific data associated with the element.

--- a/css-inline/src/html/iter.rs
+++ b/css-inline/src/html/iter.rs
@@ -1,0 +1,61 @@
+use super::{
+    document::Document,
+    element::Element,
+    selectors::{ParseError, Selectors},
+    Specificity,
+};
+
+pub(crate) fn select<'a, 'b>(
+    document: &'a Document,
+    selectors: &'b str,
+) -> Result<Select<'a>, ParseError<'b>> {
+    Iter { document }.select(selectors)
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct Iter<'a> {
+    document: &'a Document,
+    // TODO: iterator state
+}
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = Element<'a>;
+    #[inline]
+    fn next(&mut self) -> Option<Element<'a>> {
+        // TODO: Implement iteration
+        None
+    }
+}
+
+/// An element iterator adaptor that yields elements matching given selectors.
+pub(crate) struct Select<'a> {
+    iter: Iter<'a>,
+    /// The selectors to be matched.
+    selectors: Selectors,
+}
+
+impl<'a> Iter<'a> {
+    pub(super) fn select<'b>(self, selectors: &'b str) -> Result<Select<'a>, ParseError<'b>> {
+        Selectors::compile(selectors).map(|s| Select {
+            iter: self,
+            selectors: s,
+        })
+    }
+}
+
+impl<'a> Select<'a> {
+    pub(crate) fn specificity(&self) -> Specificity {
+        self.selectors.0[0].specificity()
+    }
+}
+
+impl<'a> Iterator for Select<'a> {
+    type Item = Element<'a>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Element<'a>> {
+        self.iter
+            .by_ref()
+            .find(|element| self.selectors.iter().any(|s| element.matches(s)))
+    }
+}

--- a/css-inline/src/html/mod.rs
+++ b/css-inline/src/html/mod.rs
@@ -8,5 +8,5 @@ mod selectors;
 mod serializer;
 
 pub(crate) use self::selectors::Specificity;
-pub(crate) use document::Document;
+pub(crate) use document::{Document, DEFAULT_HTML_TREE_CAPACITY};
 pub(crate) use node::NodeId;

--- a/css-inline/src/html/mod.rs
+++ b/css-inline/src/html/mod.rs
@@ -1,0 +1,12 @@
+mod attributes;
+mod document;
+mod element;
+mod iter;
+mod node;
+mod parser;
+mod selectors;
+mod serializer;
+
+pub(crate) use self::selectors::Specificity;
+pub(crate) use document::Document;
+pub(crate) use node::NodeId;

--- a/css-inline/src/html/mod.rs
+++ b/css-inline/src/html/mod.rs
@@ -8,5 +8,6 @@ mod selectors;
 mod serializer;
 
 pub(crate) use self::selectors::Specificity;
-pub(crate) use document::{Document, DEFAULT_HTML_TREE_CAPACITY};
+pub(crate) use document::Document;
+pub use document::DEFAULT_HTML_TREE_CAPACITY;
 pub(crate) use node::NodeId;

--- a/css-inline/src/html/node.rs
+++ b/css-inline/src/html/node.rs
@@ -1,0 +1,111 @@
+use super::attributes::Attributes;
+use html5ever::{tendril::StrTendril, QualName};
+use std::num::NonZeroUsize;
+
+/// Sigle node in the DOM
+#[derive(Debug, Clone)]
+pub(crate) struct Node {
+    pub(crate) parent: Option<NodeId>,
+    pub(crate) next_sibling: Option<NodeId>,
+    pub(crate) previous_sibling: Option<NodeId>,
+    pub(crate) first_child: Option<NodeId>,
+    pub(crate) last_child: Option<NodeId>,
+    /// Data specific to the type of node.
+    pub(crate) data: NodeData,
+}
+
+impl Node {
+    pub(crate) fn new(data: NodeData) -> Node {
+        Node {
+            parent: None,
+            previous_sibling: None,
+            next_sibling: None,
+            first_child: None,
+            last_child: None,
+            data,
+        }
+    }
+    pub(crate) fn as_element(&self) -> Option<&ElementData> {
+        match &self.data {
+            NodeData::Element { element: data, .. } => Some(data),
+            _ => None,
+        }
+    }
+    pub(crate) fn as_element_mut(&mut self) -> Option<&mut ElementData> {
+        match &mut self.data {
+            NodeData::Element { element: data, .. } => Some(data),
+            _ => None,
+        }
+    }
+    pub(crate) fn as_not_ignored_element_mut(&mut self) -> Option<&mut ElementData> {
+        match &mut self.data {
+            NodeData::Element {
+                element: data,
+                inlining_ignored: false,
+            } => Some(data),
+            _ => None,
+        }
+    }
+    pub(crate) fn as_text(&self) -> Option<&str> {
+        match &self.data {
+            NodeData::Text { text } => Some(&**text),
+            _ => None,
+        }
+    }
+}
+
+/// `NodeId` is a unique identifier for each `Node` in the document.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct NodeId(NonZeroUsize);
+
+impl NodeId {
+    pub(super) fn new(value: usize) -> NodeId {
+        NodeId(NonZeroUsize::new(value).expect("Value is zero"))
+    }
+    pub(super) fn document_id() -> NodeId {
+        NodeId::new(1)
+    }
+    pub(super) fn get(self) -> usize {
+        self.0.get()
+    }
+}
+
+/// Data associated with a `Node`.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum NodeData {
+    Document,
+    Doctype {
+        name: StrTendril,
+    },
+    Text {
+        text: StrTendril,
+    },
+    Comment {
+        text: StrTendril,
+    },
+    Element {
+        element: ElementData,
+        inlining_ignored: bool,
+    },
+    ProcessingInstruction {
+        target: StrTendril,
+        data: StrTendril,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ElementData {
+    /// The name (tag) of the element.
+    pub(crate) name: QualName,
+    /// The attributes associated with the element.
+    pub(crate) attributes: Attributes,
+}
+
+impl ElementData {
+    pub(crate) fn new(name: QualName, attributes: Vec<html5ever::Attribute>) -> ElementData {
+        ElementData {
+            name,
+            attributes: Attributes::new(attributes),
+        }
+    }
+}

--- a/css-inline/src/html/parser.rs
+++ b/css-inline/src/html/parser.rs
@@ -1,0 +1,265 @@
+use super::{
+    attributes::should_ignore,
+    document::Document,
+    node::{ElementData, Node, NodeData, NodeId},
+};
+use html5ever::{
+    expanded_name, local_name, namespace_url, ns,
+    tendril::{StrTendril, TendrilSink},
+    tree_builder::{ElementFlags, NodeOrText, QuirksMode, TreeSink},
+    Attribute, ExpandedName, QualName,
+};
+use std::borrow::Cow;
+
+/// Parse input bytes into an HTML document.
+pub(crate) fn parse(bytes: &[u8]) -> Document {
+    let sink = Sink {
+        document: Document::new(),
+    };
+    html5ever::parse_document(sink, html5ever::ParseOpts::default())
+        .from_utf8()
+        .one(bytes)
+}
+
+/// Intermediary structure for parsing an HTML document.
+/// It takes care of creating and appending nodes to the document as the parsing progresses.
+struct Sink {
+    /// An HTML document that is being parsed.
+    document: Document,
+}
+
+impl Sink {
+    /// Push a new node into the document.
+    fn push_node(&mut self, data: NodeData) -> NodeId {
+        self.document.push_node(data)
+    }
+
+    fn push_element(
+        &mut self,
+        name: QualName,
+        attributes: Vec<Attribute>,
+        inlining_ignored: bool,
+    ) -> NodeId {
+        self.push_node(NodeData::Element {
+            element: ElementData::new(name, attributes),
+            inlining_ignored,
+        })
+    }
+
+    fn push_text(&mut self, text: StrTendril) -> NodeId {
+        self.push_node(NodeData::Text { text })
+    }
+
+    fn push_comment(&mut self, text: StrTendril) -> NodeId {
+        self.push_node(NodeData::Comment { text })
+    }
+
+    fn push_processing_instruction(&mut self, target: StrTendril, data: StrTendril) -> NodeId {
+        self.push_node(NodeData::ProcessingInstruction { target, data })
+    }
+
+    fn push_doctype(&mut self, name: StrTendril) -> NodeId {
+        self.push_node(NodeData::Doctype { name })
+    }
+
+    /// Append a new node or text to the document.
+    fn append_impl<P, A>(&mut self, child: NodeOrText<NodeId>, previous: P, append: A)
+    where
+        P: FnOnce(&mut Document) -> Option<NodeId>,
+        A: FnOnce(&mut Document, NodeId),
+    {
+        let new_node = match child {
+            NodeOrText::AppendText(text) => {
+                // If the previous node is a text node, append to it.
+                // Otherwise create a new text node.
+                if let Some(id) = previous(&mut self.document) {
+                    if let Node {
+                        data: NodeData::Text { text: existing },
+                        ..
+                    } = &mut self.document[id]
+                    {
+                        existing.push_tendril(&text);
+                        return;
+                    }
+                }
+                self.push_text(text)
+            }
+            NodeOrText::AppendNode(node) => node,
+        };
+
+        append(&mut self.document, new_node)
+    }
+}
+
+impl TreeSink for Sink {
+    type Handle = NodeId;
+    type Output = Document;
+
+    fn finish(self) -> Document {
+        self.document
+    }
+
+    fn parse_error(&mut self, _msg: Cow<'static, str>) {}
+
+    fn get_document(&mut self) -> NodeId {
+        NodeId::document_id()
+    }
+
+    fn elem_name<'a>(&'a self, &target: &'a NodeId) -> ExpandedName<'a> {
+        self.document[target]
+            .as_element()
+            // The `TreeSink` trait promises to never call this method on non-element node
+            .expect("Not an element")
+            .name
+            .expanded()
+    }
+
+    fn create_element(
+        &mut self,
+        name: QualName,
+        attrs: Vec<Attribute>,
+        _flags: ElementFlags,
+    ) -> NodeId {
+        // Determine if we should ignore inlining for this element based on its attributes
+        let inlining_ignored = should_ignore(&attrs);
+
+        // Determine if the element is a `style` element or a linked stylesheet (`link` with `rel="stylesheet"`).
+        let (is_style, is_stylesheet) = {
+            // If inlining is ignored, we consider neither to be true.
+            if inlining_ignored {
+                (false, false)
+            } else if name.expanded() == expanded_name!(html "style") {
+                (true, false)
+            } else if name.expanded() == expanded_name!(html "link")
+                && attrs.iter().any(|attr| {
+                    attr.name.local == local_name!("rel") && attr.value == "stylesheet".into()
+                })
+            {
+                (false, true)
+            } else {
+                (false, false)
+            }
+        };
+        let element = self.push_element(name, attrs, inlining_ignored);
+        // Collect `style` tags and linked stylesheets separately to use them for CSS inlining later.
+        if is_style {
+            self.document.add_style(element)
+        }
+        if is_stylesheet {
+            self.document.add_linked_stylesheet(element)
+        }
+        element
+    }
+
+    fn create_comment(&mut self, text: StrTendril) -> NodeId {
+        self.push_comment(text)
+    }
+
+    fn create_pi(&mut self, target: StrTendril, data: StrTendril) -> NodeId {
+        self.push_processing_instruction(target, data)
+    }
+
+    /// Append a node as the last child of the given node.
+    fn append(&mut self, &parent: &NodeId, child: NodeOrText<NodeId>) {
+        self.append_impl(
+            child,
+            |document| document[parent].last_child,
+            |document, new_node| document.append(parent, new_node),
+        )
+    }
+
+    fn append_based_on_parent_node(
+        &mut self,
+        element: &NodeId,
+        prev_element: &NodeId,
+        child: NodeOrText<NodeId>,
+    ) {
+        if self.document[*element].parent.is_some() {
+            self.append_before_sibling(element, child)
+        } else {
+            self.append(prev_element, child)
+        }
+    }
+
+    /// Append a `DOCTYPE` element to the `Document` node.
+    fn append_doctype_to_document(
+        &mut self,
+        name: StrTendril,
+        _public_id: StrTendril,
+        _system_id: StrTendril,
+    ) {
+        let node = self.push_doctype(name);
+        self.document.append(NodeId::document_id(), node)
+    }
+
+    fn get_template_contents(&mut self, &target: &NodeId) -> NodeId {
+        target
+    }
+
+    /// Do two handles refer to the same node?
+    fn same_node(&self, x: &NodeId, y: &NodeId) -> bool {
+        x == y
+    }
+
+    fn set_quirks_mode(&mut self, _mode: QuirksMode) {}
+
+    /// Append a node as the sibling immediately before the given node.
+    fn append_before_sibling(&mut self, &sibling: &NodeId, child: NodeOrText<NodeId>) {
+        self.append_impl(
+            child,
+            |document| document[sibling].previous_sibling,
+            |document, node| document.insert_before(sibling, node),
+        )
+    }
+
+    /// Add each attribute to the given element, if no attribute with that name already exists.
+    fn add_attrs_if_missing(&mut self, &target: &NodeId, attrs: Vec<Attribute>) {
+        let element = self.document[target]
+            .as_element_mut()
+            .expect("not an element");
+        let attributes = &mut element.attributes;
+        for attr in attrs {
+            attributes
+                .map
+                .entry(attr.name)
+                .or_insert_with(|| attr.value);
+        }
+    }
+
+    /// Detach the given node from its parent.
+    fn remove_from_parent(&mut self, &target: &NodeId) {
+        self.document.detach(target)
+    }
+
+    /// Remove all the children from node and append them to `new_parent`.
+    fn reparent_children(&mut self, &node: &NodeId, &new_parent: &NodeId) {
+        let mut next_child = self.document[node].first_child;
+        while let Some(child) = next_child {
+            self.document.append(new_parent, child);
+            next_child = self.document[child].next_sibling
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_collect_styles() {
+        let doc = parse(b"<html><head><title>Test</title><style>h1 { color:blue; }</style><style>h1 { color:red; }</style><style data-css-inline='ignore'>h1 { color:yellow; }</style></head>");
+        let styles = doc.styles().collect::<Vec<_>>();
+        assert_eq!(styles.len(), 2);
+        assert_eq!(styles[0], "h1 { color:blue; }");
+        assert_eq!(styles[1], "h1 { color:red; }");
+    }
+
+    #[test]
+    fn test_collect_stylesheets() {
+        let doc = parse(b"<head><link href='styles1.css' rel='stylesheet' type='text/css'><link href='styles2.css' rel='stylesheet' type='text/css'><link href='styles3.css' rel='stylesheet' type='text/css' data-css-inline='ignore'></head>");
+        let links = doc.stylesheets().collect::<Vec<_>>();
+        assert_eq!(links.len(), 2);
+        assert_eq!(links[0], "styles1.css");
+        assert_eq!(links[1], "styles2.css");
+    }
+}

--- a/css-inline/src/html/parser.rs
+++ b/css-inline/src/html/parser.rs
@@ -12,9 +12,9 @@ use html5ever::{
 use std::borrow::Cow;
 
 /// Parse input bytes into an HTML document.
-pub(crate) fn parse(bytes: &[u8]) -> Document {
+pub(crate) fn parse_with_options(bytes: &[u8], preallocate_node_capacity: usize) -> Document {
     let sink = Sink {
-        document: Document::new(),
+        document: Document::with_capacity(preallocate_node_capacity),
     };
     html5ever::parse_document(sink, html5ever::ParseOpts::default())
         .from_utf8()
@@ -238,28 +238,5 @@ impl TreeSink for Sink {
             self.document.append(new_parent, child);
             next_child = self.document[child].next_sibling
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_collect_styles() {
-        let doc = parse(b"<html><head><title>Test</title><style>h1 { color:blue; }</style><style>h1 { color:red; }</style><style data-css-inline='ignore'>h1 { color:yellow; }</style></head>");
-        let styles = doc.styles().collect::<Vec<_>>();
-        assert_eq!(styles.len(), 2);
-        assert_eq!(styles[0], "h1 { color:blue; }");
-        assert_eq!(styles[1], "h1 { color:red; }");
-    }
-
-    #[test]
-    fn test_collect_stylesheets() {
-        let doc = parse(b"<head><link href='styles1.css' rel='stylesheet' type='text/css'><link href='styles2.css' rel='stylesheet' type='text/css'><link href='styles3.css' rel='stylesheet' type='text/css' data-css-inline='ignore'></head>");
-        let links = doc.stylesheets().collect::<Vec<_>>();
-        assert_eq!(links.len(), 2);
-        assert_eq!(links[0], "styles1.css");
-        assert_eq!(links[1], "styles2.css");
     }
 }

--- a/css-inline/src/html/parser.rs
+++ b/css-inline/src/html/parser.rs
@@ -130,12 +130,22 @@ impl TreeSink for Sink {
                 (false, false)
             } else if name.expanded() == expanded_name!(html "style") {
                 (true, false)
-            } else if name.expanded() == expanded_name!(html "link")
-                && attrs.iter().any(|attr| {
-                    attr.name.local == local_name!("rel") && attr.value == "stylesheet".into()
-                })
-            {
-                (false, true)
+            } else if name.expanded() == expanded_name!(html "link") {
+                let mut rel_stylesheet = false;
+                let mut href_non_empty = false;
+                for attr in &attrs {
+                    if attr.name.local == local_name!("rel") && attr.value == "stylesheet".into() {
+                        rel_stylesheet = true;
+                    }
+                    // Skip links with empty `href` attributes
+                    if attr.name.local == local_name!("href") && !attr.value.is_empty() {
+                        href_non_empty = true;
+                    }
+                    if rel_stylesheet && href_non_empty {
+                        break;
+                    }
+                }
+                (false, rel_stylesheet && href_non_empty)
             } else {
                 (false, false)
             }

--- a/css-inline/src/html/selectors/attr_value.rs
+++ b/css-inline/src/html/selectors/attr_value.rs
@@ -1,0 +1,28 @@
+use cssparser::ToCss;
+use html5ever::tendril::StrTendril;
+use std::{fmt, fmt::Write};
+
+/// To use `StrTendril` in selectors, we need to implement `ToCss` on a wrapper.
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
+pub(crate) struct AttrValue(StrTendril);
+
+impl ToCss for AttrValue {
+    fn to_css<W>(&self, dest: &mut W) -> fmt::Result
+    where
+        W: Write,
+    {
+        write!(cssparser::CssStringWriter::new(dest), "{}", &self.0)
+    }
+}
+
+impl<'a> From<&'a str> for AttrValue {
+    fn from(string: &'a str) -> Self {
+        Self(string.into())
+    }
+}
+
+impl AsRef<str> for AttrValue {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}

--- a/css-inline/src/html/selectors/local_name.rs
+++ b/css-inline/src/html/selectors/local_name.rs
@@ -1,0 +1,45 @@
+use cssparser::ToCss;
+use std::fmt::Write;
+
+/// `LocalName` type wraps `html5ever::LocalName` to extend it by implementing the `ToCss` trait,
+/// which is needed for selectors implementation.
+#[derive(Debug, Default, PartialEq, Eq, Hash, Clone, PartialOrd, Ord)]
+pub(crate) struct LocalName(html5ever::LocalName);
+
+impl LocalName {
+    /// Returns the inner `html5ever::LocalName`.
+    pub(crate) fn into_inner(self) -> html5ever::LocalName {
+        self.0
+    }
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+impl PartialEq<LocalName> for html5ever::LocalName {
+    fn eq(&self, other: &LocalName) -> bool {
+        self.eq(&other.0)
+    }
+}
+
+impl From<html5ever::LocalName> for LocalName {
+    fn from(value: html5ever::LocalName) -> Self {
+        LocalName(value)
+    }
+}
+
+impl<'a> From<&'a str> for LocalName {
+    fn from(value: &'a str) -> Self {
+        LocalName(html5ever::LocalName::from(value))
+    }
+}
+
+impl ToCss for LocalName {
+    fn to_css<W>(&self, dest: &mut W) -> std::fmt::Result
+    where
+        W: Write,
+    {
+        // Write the `LocalName` to the destination, which is the CSS syntax.
+        dest.write_str(self.0.as_ref())
+    }
+}

--- a/css-inline/src/html/selectors/mod.rs
+++ b/css-inline/src/html/selectors/mod.rs
@@ -1,0 +1,63 @@
+mod attr_value;
+mod local_name;
+mod parser;
+mod pseudo_classes;
+mod pseudo_elements;
+mod selector_impl;
+
+pub(super) use attr_value::AttrValue;
+pub(super) use local_name::LocalName;
+pub(super) use pseudo_classes::PseudoClass;
+pub(super) use pseudo_elements::PseudoElement;
+pub(super) use selector_impl::InlinerSelectors;
+
+use selectors::{
+    parser::{Selector as GenericSelector, SelectorParseErrorKind},
+    SelectorList,
+};
+
+/// A pre-compiled CSS Selector.
+pub(crate) struct Selector(GenericSelector<InlinerSelectors>);
+
+/// A pre-compiled list of CSS Selectors.
+pub(crate) struct Selectors(pub(crate) Vec<Selector>);
+
+/// The specificity of a selector.
+/// Determines precedence in the cascading algorithm.
+/// When equal, a rule later in source order takes precedence.
+#[derive(Copy, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub(crate) struct Specificity(u32);
+
+pub(crate) type ParseError<'i> = cssparser::ParseError<'i, SelectorParseErrorKind<'i>>;
+
+/// Parse CSS selectors into `SelectorList`.
+fn parse(selectors: &str) -> Result<SelectorList<InlinerSelectors>, ParseError<'_>> {
+    let mut input = cssparser::ParserInput::new(selectors);
+    let parser = &mut cssparser::Parser::new(&mut input);
+    SelectorList::parse(&parser::SelectorParser, parser)
+}
+
+impl Selectors {
+    /// Compile a list of selectors.
+    #[inline]
+    pub(super) fn compile(selectors: &str) -> Result<Selectors, ParseError<'_>> {
+        parse(selectors).map(|list| Selectors(list.0.into_iter().map(Selector).collect()))
+    }
+
+    /// Iterator over selectors.
+    #[inline]
+    pub(super) fn iter(&self) -> impl Iterator<Item = &Selector> {
+        self.0.iter()
+    }
+}
+
+impl Selector {
+    /// Inner selector value.
+    pub(crate) fn inner_value(&self) -> &GenericSelector<InlinerSelectors> {
+        &self.0
+    }
+    /// Specificity of this selector.
+    pub(crate) fn specificity(&self) -> Specificity {
+        Specificity(self.0.specificity())
+    }
+}

--- a/css-inline/src/html/selectors/parser.rs
+++ b/css-inline/src/html/selectors/parser.rs
@@ -1,0 +1,46 @@
+use super::{pseudo_classes::PseudoClass, selector_impl::InlinerSelectors, ParseError};
+use cssparser::{CowRcStr, SourceLocation};
+use selectors::{parser::SelectorParseErrorKind, Parser};
+
+/// CSS selector parser.
+pub(crate) struct SelectorParser;
+
+impl<'i> Parser<'i> for SelectorParser {
+    type Impl = InlinerSelectors;
+    type Error = SelectorParseErrorKind<'i>;
+
+    fn parse_non_ts_pseudo_class(
+        &self,
+        location: SourceLocation,
+        name: CowRcStr<'i>,
+    ) -> Result<PseudoClass, ParseError<'i>> {
+        use self::PseudoClass::*;
+        if name.eq_ignore_ascii_case("any-link") {
+            Ok(AnyLink)
+        } else if name.eq_ignore_ascii_case("link") {
+            Ok(Link)
+        } else if name.eq_ignore_ascii_case("visited") {
+            Ok(Visited)
+        } else if name.eq_ignore_ascii_case("active") {
+            Ok(Active)
+        } else if name.eq_ignore_ascii_case("focus") {
+            Ok(Focus)
+        } else if name.eq_ignore_ascii_case("hover") {
+            Ok(Hover)
+        } else if name.eq_ignore_ascii_case("enabled") {
+            Ok(Enabled)
+        } else if name.eq_ignore_ascii_case("disabled") {
+            Ok(Disabled)
+        } else if name.eq_ignore_ascii_case("checked") {
+            Ok(Checked)
+        } else if name.eq_ignore_ascii_case("indeterminate") {
+            Ok(Indeterminate)
+        } else {
+            Err(
+                location.new_custom_error(SelectorParseErrorKind::UnsupportedPseudoClassOrElement(
+                    name,
+                )),
+            )
+        }
+    }
+}

--- a/css-inline/src/html/selectors/pseudo_classes.rs
+++ b/css-inline/src/html/selectors/pseudo_classes.rs
@@ -1,0 +1,53 @@
+use super::selector_impl::InlinerSelectors;
+use cssparser::ToCss;
+use selectors::parser::NonTSPseudoClass;
+use std::fmt;
+
+#[derive(PartialEq, Eq, Clone, Debug, Hash)]
+pub(crate) enum PseudoClass {
+    AnyLink,
+    Link,
+    Visited,
+    Active,
+    Focus,
+    Hover,
+    Enabled,
+    Disabled,
+    Checked,
+    Indeterminate,
+}
+
+impl NonTSPseudoClass for PseudoClass {
+    type Impl = InlinerSelectors;
+
+    fn is_active_or_hover(&self) -> bool {
+        matches!(*self, PseudoClass::Active | PseudoClass::Hover)
+    }
+
+    fn is_user_action_state(&self) -> bool {
+        matches!(
+            *self,
+            PseudoClass::Active | PseudoClass::Hover | PseudoClass::Focus
+        )
+    }
+}
+
+impl ToCss for PseudoClass {
+    fn to_css<W>(&self, dest: &mut W) -> fmt::Result
+    where
+        W: fmt::Write,
+    {
+        dest.write_str(match *self {
+            PseudoClass::AnyLink => ":any-link",
+            PseudoClass::Link => ":link",
+            PseudoClass::Visited => ":visited",
+            PseudoClass::Active => ":active",
+            PseudoClass::Focus => ":focus",
+            PseudoClass::Hover => ":hover",
+            PseudoClass::Enabled => ":enabled",
+            PseudoClass::Disabled => ":disabled",
+            PseudoClass::Checked => ":checked",
+            PseudoClass::Indeterminate => ":indeterminate",
+        })
+    }
+}

--- a/css-inline/src/html/selectors/pseudo_elements.rs
+++ b/css-inline/src/html/selectors/pseudo_elements.rs
@@ -1,0 +1,19 @@
+use super::selector_impl::InlinerSelectors;
+use cssparser::ToCss;
+use std::fmt;
+
+#[derive(PartialEq, Eq, Clone, Debug, Hash)]
+pub(crate) enum PseudoElement {}
+
+impl ToCss for PseudoElement {
+    fn to_css<W>(&self, _dest: &mut W) -> fmt::Result
+    where
+        W: fmt::Write,
+    {
+        match *self {}
+    }
+}
+
+impl selectors::parser::PseudoElement for PseudoElement {
+    type Impl = InlinerSelectors;
+}

--- a/css-inline/src/html/selectors/selector_impl.rs
+++ b/css-inline/src/html/selectors/selector_impl.rs
@@ -1,0 +1,24 @@
+use super::{
+    attr_value::AttrValue, local_name::LocalName, pseudo_classes::PseudoClass,
+    pseudo_elements::PseudoElement,
+};
+use html5ever::Namespace;
+use selectors::SelectorImpl;
+
+/// CSS selectors implementation. It is needed to parametrize the parser implementation in regards
+/// of pseudo-classes and elements.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct InlinerSelectors;
+
+impl SelectorImpl for InlinerSelectors {
+    type ExtraMatchingData = ();
+    type AttrValue = AttrValue;
+    type Identifier = LocalName;
+    type LocalName = LocalName;
+    type NamespaceUrl = Namespace;
+    type NamespacePrefix = LocalName;
+    type BorrowedNamespaceUrl = Namespace;
+    type BorrowedLocalName = LocalName;
+    type NonTSPseudoClass = PseudoClass;
+    type PseudoElement = PseudoElement;
+}

--- a/css-inline/src/html/serializer.rs
+++ b/css-inline/src/html/serializer.rs
@@ -55,7 +55,6 @@ impl<'a> Sink<'a> {
 
 impl<'a> Serialize for Sink<'a> {
     fn serialize<S: Serializer>(&self, serializer: &mut S, _: TraversalScope) -> io::Result<()> {
-        // TODO: Consider iteration over recursion
         match self.data() {
             NodeData::Element { element, .. } => {
                 if self.should_skip_element(element) {

--- a/css-inline/src/html/serializer.rs
+++ b/css-inline/src/html/serializer.rs
@@ -1,0 +1,111 @@
+use super::{
+    document::Document,
+    node::{ElementData, NodeData, NodeId},
+};
+use html5ever::{
+    local_name, serialize,
+    serialize::{Serialize, SerializeOpts, Serializer, TraversalScope},
+};
+use std::{io, io::Write};
+
+pub(crate) fn serialize_to<W: Write>(
+    document: &Document,
+    writer: &mut W,
+    skip_style_tags: bool,
+) -> io::Result<()> {
+    let sink = Sink::new(document, NodeId::document_id(), skip_style_tags);
+    serialize(writer, &sink, SerializeOpts::default())
+}
+
+/// Intermediary structure for serializing an HTML document.
+struct Sink<'a> {
+    document: &'a Document,
+    node: NodeId,
+    skip_style_tags: bool,
+}
+
+impl<'a> Sink<'a> {
+    fn new(document: &'a Document, node: NodeId, skip_style_tags: bool) -> Sink<'a> {
+        Sink {
+            document,
+            node,
+            skip_style_tags,
+        }
+    }
+    fn for_node(&self, node: NodeId) -> Sink<'a> {
+        Sink::new(self.document, node, self.skip_style_tags)
+    }
+    fn data(&self) -> &NodeData {
+        &self.document[self.node].data
+    }
+    fn should_skip_element(&self, element: &ElementData) -> bool {
+        self.skip_style_tags && element.name.local == local_name!("style")
+    }
+    fn serialize_children<S: Serializer>(&self, serializer: &mut S) -> io::Result<()> {
+        for child in self.document.children(self.node) {
+            Serialize::serialize(
+                &self.for_node(child),
+                serializer,
+                TraversalScope::IncludeNode,
+            )?
+        }
+        Ok(())
+    }
+}
+
+impl<'a> Serialize for Sink<'a> {
+    fn serialize<S: Serializer>(&self, serializer: &mut S, _: TraversalScope) -> io::Result<()> {
+        // TODO: Consider iteration over recursion
+        match self.data() {
+            NodeData::Element { element, .. } => {
+                if self.should_skip_element(element) {
+                    return Ok(());
+                }
+                serializer.start_elem(
+                    element.name.clone(),
+                    element
+                        .attributes
+                        .map
+                        .iter()
+                        .map(|(name, value)| (name, &**value)),
+                )?;
+
+                self.serialize_children(serializer)?;
+
+                serializer.end_elem(element.name.clone())?;
+                Ok(())
+            }
+            NodeData::Document => self.serialize_children(serializer),
+            NodeData::Doctype { name } => serializer.write_doctype(name),
+            NodeData::Text { text: content } => serializer.write_text(content),
+            NodeData::Comment { text } => serializer.write_comment(text),
+            NodeData::ProcessingInstruction { target, data } => {
+                serializer.write_processing_instruction(target, data)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Document;
+
+    #[test]
+    fn test_serialize() {
+        let doc = Document::parse(b"<html><head><title>Test</title><style>h1 { color:blue; }</style><style>h1 { color:red; }</style></head>");
+        let mut buffer = Vec::new();
+        doc.serialize(&mut buffer, false).expect("Should not fail");
+        assert_eq!(buffer, b"<html><head><title>Test</title><style>h1 { color:blue; }</style><style>h1 { color:red; }</style></head><body></body></html>")
+    }
+
+    #[test]
+    fn test_skip_style_tags() {
+        let doc = Document::parse(b"<html><head><title>Test</title><style>h1 { color:blue; }</style><style>h1 { color:red; }</style></head>");
+        let mut buffer = Vec::new();
+        doc.serialize(&mut buffer, true).expect("Should not fail");
+        assert_eq!(
+            buffer,
+            b"<html><head><title>Test</title></head><body></body></html>"
+        )
+    }
+}

--- a/css-inline/src/html/serializer.rs
+++ b/css-inline/src/html/serializer.rs
@@ -92,7 +92,7 @@ mod tests {
 
     #[test]
     fn test_serialize() {
-        let doc = Document::parse(b"<html><head><title>Test</title><style>h1 { color:blue; }</style><style>h1 { color:red; }</style></head>");
+        let doc = Document::parse_with_options(b"<html><head><title>Test</title><style>h1 { color:blue; }</style><style>h1 { color:red; }</style></head>", 0);
         let mut buffer = Vec::new();
         doc.serialize(&mut buffer, false).expect("Should not fail");
         assert_eq!(buffer, b"<html><head><title>Test</title><style>h1 { color:blue; }</style><style>h1 { color:red; }</style></head><body></body></html>")
@@ -100,7 +100,7 @@ mod tests {
 
     #[test]
     fn test_skip_style_tags() {
-        let doc = Document::parse(b"<html><head><title>Test</title><style>h1 { color:blue; }</style><style>h1 { color:red; }</style></head>");
+        let doc = Document::parse_with_options(b"<html><head><title>Test</title><style>h1 { color:blue; }</style><style>h1 { color:red; }</style></head>", 0);
         let mut buffer = Vec::new();
         doc.serialize(&mut buffer, true).expect("Should not fail");
         assert_eq!(

--- a/css-inline/src/lib.rs
+++ b/css-inline/src/lib.rs
@@ -25,11 +25,8 @@
     rust_2018_compatibility
 )]
 
-use kuchiki::{
-    parse_html, traits::TendrilSink, ElementData, Node, NodeDataRef, NodeRef, Specificity,
-};
-
 pub mod error;
+mod html;
 mod parser;
 
 pub use error::InlineError;
@@ -40,6 +37,7 @@ use std::{
     io::{ErrorKind, Write},
 };
 
+use crate::html::{Document, NodeId, Specificity};
 pub use url::{ParseError, Url};
 
 /// Replace double quotes in property values.
@@ -145,7 +143,6 @@ impl Default for InlineOptions<'_> {
 }
 
 type Result<T> = std::result::Result<T, InlineError>;
-const CSS_INLINE_ATTRIBUTE: &str = "data-css-inline";
 
 /// Customizable CSS inliner.
 #[derive(Debug)]
@@ -226,7 +223,7 @@ impl<'a> CSSInliner<'a> {
     ///   - Internal CSS selector parsing error;
     #[inline]
     pub fn inline_to<W: Write>(&self, html: &str, target: &mut W) -> Result<()> {
-        let document = parse_html().one(html);
+        let mut document = Document::parse(html.as_bytes());
         // CSS rules may overlap, and the final set of rules applied to an element depend on
         // selectors' specificity - selectors with higher specificity have more priority.
         // Inlining happens in two major steps:
@@ -234,57 +231,15 @@ impl<'a> CSSInliner<'a> {
         //      selector's specificity. When two rules overlap on the same declaration, then
         //      the one with higher specificity replaces another.
         //   2. Resulting styles are merged into existing "style" tags.
-        #[allow(clippy::mutable_key_type)]
-        // Each matched element is identified by their raw pointers - they are evaluated once
-        // and then reused, which allows O(1) access to find them.
-        // Internally, their raw pointers are used to implement `Eq`, which seems like the only
-        // reasonable approach to compare them (performance-wise).
         let mut styles = IndexMap::with_capacity(128);
-        let mut style_tags: SmallVec<[NodeDataRef<ElementData>; 4]> = smallvec![];
         if self.options.inline_style_tags {
-            for style_tag in document
-                .select("style")
-                .map_err(|_| InlineError::ParseError(Cow::from("Unknown error")))?
-            {
-                if style_tag.attributes.borrow().get(CSS_INLINE_ATTRIBUTE) == Some("ignore") {
-                    continue;
-                }
-                if let Some(first_child) = style_tag.as_node().first_child() {
-                    if let Some(css_cell) = first_child.as_text() {
-                        process_css(&document, css_cell.borrow().as_str(), &mut styles);
-                    }
-                }
-                if self.options.remove_style_tags {
-                    style_tags.push(style_tag);
-                }
+            for style in document.styles() {
+                process_css(&document, style, &mut styles);
             }
         }
-        if self.options.remove_style_tags {
-            if !self.options.inline_style_tags {
-                style_tags.extend(
-                    document
-                        .select("style")
-                        .map_err(|_| error::InlineError::ParseError(Cow::from("Unknown error")))?,
-                );
-            }
-            for style_tag in &style_tags {
-                style_tag.as_node().detach();
-            }
-        }
-
         if self.options.load_remote_stylesheets {
-            let mut links = document
-                .select("link[rel~=stylesheet]")
-                .map_err(|_| error::InlineError::ParseError(Cow::from("Unknown error")))?
-                .filter_map(|link_tag| {
-                    if link_tag.attributes.borrow().get(CSS_INLINE_ATTRIBUTE) == Some("ignore") {
-                        None
-                    } else {
-                        link_tag.attributes.borrow().get("href").map(str::to_string)
-                    }
-                })
-                .filter(|link| !link.is_empty())
-                .collect::<Vec<String>>();
+            // TODO: Implement skipping + skip empty links
+            let mut links = document.stylesheets().collect::<Vec<&str>>();
             links.sort_unstable();
             links.dedup();
             for href in &links {
@@ -297,39 +252,27 @@ impl<'a> CSSInliner<'a> {
             process_css(&document, extra_css, &mut styles);
         }
         for (node_id, styles) in styles {
-            // SAFETY: All nodes are alive as long as `document` is in scope.
-            // Therefore, any `document` children should be alive and it is safe to dereference
-            // pointers to them
-            let node = unsafe { &*node_id };
-            // It can be borrowed if the current selector matches <link> tag, that is
-            // already borrowed in `inline_to`. We can ignore such matches
-            if let Ok(mut attributes) = node
-                .as_element()
-                .expect("Element is expected")
-                .attributes
-                .try_borrow_mut()
-            {
-                // Skip inlining for tags that have `data-css-inline="ignore"` attribute
-                if attributes.get(CSS_INLINE_ATTRIBUTE) == Some("ignore") {
-                    continue;
+            let node = &mut document[node_id];
+            let Some(element) = node.as_not_ignored_element_mut() else {
+                continue;
+            };
+            let attributes = &mut element.attributes;
+            if let Some(existing_style) = attributes.get_style_mut() {
+                *existing_style = merge_styles(existing_style, &styles)?.into();
+            } else {
+                let mut final_styles = String::with_capacity(128);
+                let mut styles = styles.iter().collect::<Vec<_>>();
+                styles.sort_unstable_by(|(_, (a, _)), (_, (b, _))| a.cmp(b));
+                for (name, (_, value)) in styles {
+                    final_styles.push_str(name.as_str());
+                    final_styles.push(':');
+                    replace_double_quotes!(final_styles, name, value);
+                    final_styles.push(';');
                 }
-                if let Some(existing_style) = attributes.get_mut("style") {
-                    *existing_style = merge_styles(existing_style, &styles)?;
-                } else {
-                    let mut final_styles = String::with_capacity(128);
-                    let mut styles = styles.iter().collect::<Vec<_>>();
-                    styles.sort_unstable_by(|(_, (a, _)), (_, (b, _))| a.cmp(b));
-                    for (name, (_, value)) in styles {
-                        final_styles.push_str(name.as_str());
-                        final_styles.push(':');
-                        replace_double_quotes!(final_styles, name, value);
-                        final_styles.push(';');
-                    }
-                    attributes.insert("style", final_styles);
-                };
-            }
+                attributes.set_style(final_styles);
+            };
         }
-        document.serialize(target)?;
+        document.serialize(target, self.options.remove_style_tags)?;
         Ok(())
     }
 
@@ -390,11 +333,9 @@ fn load_external(mut location: &str) -> Result<String> {
     }
 }
 
-type NodeId = *const Node;
-
 #[allow(clippy::mutable_key_type)]
 fn process_css(
-    document: &NodeRef,
+    document: &Document,
     css: &str,
     styles: &mut IndexMap<NodeId, IndexMap<String, (Specificity, String)>>,
 ) {
@@ -408,10 +349,10 @@ fn process_css(
         for selector in selectors.split(',') {
             if let Ok(matching_elements) = document.select(selector) {
                 // There is always only one selector applied
-                let specificity = matching_elements.selectors.0[0].specificity();
+                let specificity = matching_elements.specificity();
                 for matching_element in matching_elements {
                     let element_styles = styles
-                        .entry(&**matching_element.as_node())
+                        .entry(matching_element.node_id)
                         .or_insert_with(|| IndexMap::with_capacity(8));
                     // Iterate over pairs of property name & value
                     // Example: `padding`, `0`

--- a/css-inline/src/lib.rs
+++ b/css-inline/src/lib.rs
@@ -266,7 +266,9 @@ impl<'a> CSSInliner<'a> {
         }
         for (node_id, styles) in styles {
             let node = &mut document[node_id];
-            let Some(element) = node.as_not_ignored_element_mut() else {
+            let element = if let Some(element) = node.as_not_ignored_element_mut() {
+                element
+            } else {
                 continue;
             };
             let attributes = &mut element.attributes;

--- a/css-inline/src/lib.rs
+++ b/css-inline/src/lib.rs
@@ -37,7 +37,8 @@ use std::{
     io::{ErrorKind, Write},
 };
 
-use crate::html::{Document, NodeId, Specificity, DEFAULT_HTML_TREE_CAPACITY};
+use crate::html::{Document, NodeId, Specificity};
+pub use html::DEFAULT_HTML_TREE_CAPACITY;
 pub use url::{ParseError, Url};
 
 /// Replace double quotes in property values.
@@ -251,7 +252,7 @@ impl<'a> CSSInliner<'a> {
             }
         }
         if self.options.load_remote_stylesheets {
-            // TODO: Implement skipping + skip empty links
+            // TODO: skip empty links
             let mut links = document.stylesheets().collect::<Vec<&str>>();
             links.sort_unstable();
             links.dedup();

--- a/css-inline/src/lib.rs
+++ b/css-inline/src/lib.rs
@@ -252,7 +252,6 @@ impl<'a> CSSInliner<'a> {
             }
         }
         if self.options.load_remote_stylesheets {
-            // TODO: skip empty links
             let mut links = document.stylesheets().collect::<Vec<&str>>();
             links.sort_unstable();
             links.dedup();

--- a/css-inline/src/main.rs
+++ b/css-inline/src/main.rs
@@ -98,6 +98,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             base_url: parse_url(args.base_url)?,
             load_remote_stylesheets: args.load_remote_stylesheets,
             extra_css: args.extra_css.as_deref().map(Cow::Borrowed),
+            ..Default::default()
         };
         let inliner = CSSInliner::new(options);
         if args.files.is_empty() {


### PR DESCRIPTION
Resolves #176 