### PR TITLE
fix: Serialize all HTML attributes without escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Serialize all HTML attributes without escaping. [#184](https://github.com/Stranger6667/css-inline/issues/184)
+
 ### Internal
 
 - Replaced the `kuchiki` crate with our custom-built HTML tree representation. [#176](https://github.com/Stranger6667/css-inline/issues/176)

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Serialize all HTML attributes without escaping. [#184](https://github.com/Stranger6667/css-inline/issues/184)
+
 ### Changed
 
 - Update `PyO3` to `0.19.0`.

--- a/bindings/wasm/CHANGELOG.md
+++ b/bindings/wasm/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Serialize all HTML attributes without escaping. [#184](https://github.com/Stranger6667/css-inline/issues/184)
+
 ### Performance
 
 - 15-30% average performance improvement due switch from `kuchiki` to a custom-built HTML tree representation.

--- a/css-inline/src/html/iter.rs
+++ b/css-inline/src/html/iter.rs
@@ -7,6 +7,7 @@ use super::{
 };
 
 /// Compile selectors from a string and create an element iterator that yields elements matching these selectors.
+#[inline]
 pub(crate) fn select<'a, 'b>(
     document: &'a Document,
     selectors: &'b str,
@@ -59,6 +60,7 @@ pub(crate) struct Select<'a> {
 
 impl<'a> Select<'a> {
     /// Specificity of the first selector in the list of selectors.
+    #[inline]
     pub(crate) fn specificity(&self) -> Specificity {
         self.selectors.0[0].specificity()
     }

--- a/css-inline/tests/test_inlining.rs
+++ b/css-inline/tests/test_inlining.rs
@@ -194,6 +194,34 @@ fn font_family_quoted() {
 }
 
 #[test]
+fn href_attribute_unchanged() {
+    // All HTML attributes should be serialized as is
+    let html = r#"<html>
+<head>
+    <title>Test</title>
+    <style>h1 { color:blue; }</style>
+</head>
+<body>
+    <h1>Big Text</h1>
+    <a href="https://example.org/test?a=b&c=d">Link</a>
+</body>
+</html>"#;
+    let inlined = inline(html).unwrap();
+    assert_eq!(
+        inlined,
+        r#"<html><head>
+    <title>Test</title>
+    <style>h1 { color:blue; }</style>
+</head>
+<body>
+    <h1 style="color:blue;">Big Text</h1>
+    <a href="https://example.org/test?a=b&c=d">Link</a>
+
+</body></html>"#
+    );
+}
+
+#[test]
 fn existing_styles() {
     // When there is a `style` attribute on a tag that contains a rule
     // And the `style` tag contains the same rule applicable to that tag


### PR DESCRIPTION
Fixes #184

It also **significantly** improves performance.