### PR TITLE
include license file in python source distribution

### DIFF
--- a/bindings/python/LICENSE
+++ b/bindings/python/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-2023 Dmitry Dygalo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -18,7 +18,7 @@ keywords = ["css", "html", "email", "stylesheet", "inlining"]
 authors = [
     { name = "Dmitry Dygalo", email = "dmitry@dygalo.dev" }
 ]
-license = { text = "MIT" }
+license = { file = "LICENSE" }
 classifiers=[
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",


### PR DESCRIPTION
It would be helpful to include the license file in the source distribution. I was packaging `css-line` for conda-forge (https://github.com/conda-forge/staged-recipes/pull/24122)  and we typically prefer to have the license file included. For now I've made a manual copy, but it would be better for it to come from the upstream source.

I ended up just making a copy of `LICENSE` in the python binding directory since the `pyproject.toml` didn't seem to like relative paths that included `../..`. It looks like you already have another copy in the `wasm` binding directory, so I thought this was likely ok.