### PR TITLE
fix: double quote when extending inline styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Bump MSRV to `1.70`.
 
+### Fixed
+
+- Replace double quotes when merging styles. [#392](https://github.com/Stranger6667/css-inline/issues/392)
+
 ## [0.14.1] - 2024-04-27
 
 ### Fixed

--- a/bindings/c/CHANGELOG.md
+++ b/bindings/c/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Bump MSRV to `1.70`.
 
+### Fixed
+
+- Replace double quotes when merging styles. [#392](https://github.com/Stranger6667/css-inline/issues/392)
+
 ## [0.14.1] - 2024-04-27
 
 ### Fixed

--- a/bindings/javascript/CHANGELOG.md
+++ b/bindings/javascript/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Build on `linux-arm-gnueabihf`
+- Replace double quotes when merging styles. [#392](https://github.com/Stranger6667/css-inline/issues/392)
 
 ## [0.14.1] - 2024-04-27
 

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Update `PyO3` to `0.22.0`.
 - Bump MSRV to `1.70`.
 
+### Fixed
+
+- Replace double quotes when merging styles. [#392](https://github.com/Stranger6667/css-inline/issues/392)
+
 ## [0.14.1] - 2024-04-27
 
 ### Fixed

--- a/bindings/ruby/CHANGELOG.md
+++ b/bindings/ruby/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Update `magnus` to `0.7`.
 - Bump MSRV to `1.70`.
 
+### Fixed
+
+- Replace double quotes when merging styles. [#392](https://github.com/Stranger6667/css-inline/issues/392)
+
 ## [0.14.1] - 2024-04-27
 
 ### Fixed

--- a/css-inline/tests/test_inlining.rs
+++ b/css-inline/tests/test_inlining.rs
@@ -268,6 +268,28 @@ fn font_family_quoted() {
 }
 
 #[test]
+fn font_family_quoted_with_existing_inline_style() {
+    // When property value contains double quotes
+    assert_inlined!(
+        style = r#"h1 { font-family: "Open Sans", sans-serif; }"#,
+        body = r#"<h1 style="whitespace: nowrap">Hello world!</h1>"#,
+        // Then it should be replaced with single quotes
+        expected = r#"<h1 style="font-family: 'Open Sans', sans-serif;whitespace: nowrap">Hello world!</h1>"#
+    )
+}
+
+#[test]
+fn font_family_quoted_with_inline_style_override() {
+    // When property value contains double quotes
+    assert_inlined!(
+        style = r#"h1 { font-family: "Open Sans", sans-serif !important; }"#,
+        body = r#"<h1 style="font-family: Helvetica; whitespace: nowrap">Hello world!</h1>"#,
+        // Then it should be replaced with single quotes
+        expected = r#"<h1 style="font-family: 'Open Sans', sans-serif;whitespace: nowrap">Hello world!</h1>"#
+    )
+}
+
+#[test]
 fn other_property_quoted() {
     // When property value contains double quotes
     assert_inlined!(


### PR DESCRIPTION
fixes https://github.com/Stranger6667/css-inline/issues/392

I believe the issue is that the `write_declaration` method — which is responsible for replacing double quotes — is not called when there are existing styles.

In order to preserve the performance optimization of not rewriting the name in the case where we're overwriting an existing style, I split out `write_declaration_value` from `write_declaration` so that it could be used independently. I have low confidence about this.

Please let me know how I can improve this patch, or feel free to run with this as a start.

Thanks again!