### PR TITLE
fix: prioritize important styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Prioritize `!important` rules when computing element styles. [#398](https://github.com/Stranger6667/css-inline/pull/398)
+
 ## [0.14.2] - 2024-11-11
 
 ### Changed

--- a/bindings/c/CHANGELOG.md
+++ b/bindings/c/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Prioritize `!important` rules when computing element styles. [#398](https://github.com/Stranger6667/css-inline/pull/398)
+
 ## [0.14.2] - 2024-11-11
 
 ### Changed

--- a/bindings/javascript/CHANGELOG.md
+++ b/bindings/javascript/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Prioritize `!important` rules when computing element styles. [#398](https://github.com/Stranger6667/css-inline/pull/398)
+
 ## [0.14.2] - 2024-11-11
 
 ### Changed

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Prioritize `!important` rules when computing element styles. [#398](https://github.com/Stranger6667/css-inline/pull/398)
+
 ## [0.14.2] - 2024-11-11
 
 ### Changed

--- a/bindings/ruby/CHANGELOG.md
+++ b/bindings/ruby/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Prioritize `!important` rules when computing element styles. [#398](https://github.com/Stranger6667/css-inline/pull/398)
+
 ## [0.14.2] - 2024-11-11
 
 ### Changed

--- a/css-inline/tests/test_inlining.rs
+++ b/css-inline/tests/test_inlining.rs
@@ -257,6 +257,32 @@ fn important_no_rule_exists() {
 }
 
 #[test]
+fn important_multiple_rules() {
+    // `!important` rules should override other rules with the same specificity.
+    assert_inlined!(
+        style = ".blue { color: blue !important; } .reset { color: unset }",
+        body = r#"<h1 class="blue reset">Big Text</h1>"#,
+        expected = r#"<h1 class="blue reset" style="color: blue !important;">Big Text</h1>"#
+    );
+    // check in both directions
+    assert_inlined!(
+        style = ".reset { color: unset } .blue { color: blue !important; }",
+        body = r#"<h1 class="blue reset">Big Text</h1>"#,
+        expected = r#"<h1 class="blue reset" style="color: blue !important;">Big Text</h1>"#
+    );
+}
+
+#[test]
+fn important_more_specific() {
+    // `!important` rules should override other important rules with less specificity.
+    assert_inlined!(
+        style = "h1 { color: unset !important } #title { color: blue !important; }",
+        body = r#"<h1 id="title">Big Text</h1>"#,
+        expected = r#"<h1 id="title" style="color: blue !important;">Big Text</h1>"#
+    );
+}
+
+#[test]
 fn font_family_quoted() {
     // When property value contains double quotes
     assert_inlined!(


### PR DESCRIPTION
When two selectors would set a property for an element, if one of those selectors is important then it should take precedence over non-important selector. If they are both important, or neither are important, then specificity is enough.

I observed this issue when comparing generated emails against the output of the node `inline-css` library. Here's a simple playground input/output that demonstrates the problem:

```
<html>
  <head>
    <style>
      .tw-text-secondary { color: rgb(119, 119, 119) !important; }
      ._reset_q8zsn_1 { color: unset; }
    </style>
  </head>
  <body>
    <span class="_reset_q8zsn_1 tw-text-secondary">Big Text</span>
  </body>
</html>
```

```
<html><head>
    
  </head>
  <body>
    <span class="pc-reset _reset_q8zsn_1 tw-font-body tw-text-ssm tw-text-substack-secondary" style="color: unset;">Big Text</span>
  
</body></html>
```

Note that if you reverse the order of the rule declarations, you get the correct behavior.