### PR TITLE
feat(loader): fallback to wasm when native binding missing

### DIFF
--- a/bindings/javascript/index.js
+++ b/bindings/javascript/index.js
@@ -246,10 +246,14 @@ switch (platform) {
 }
 
 if (!nativeBinding) {
-  if (loadError) {
-    throw loadError
+  try {
+    nativeBinding = require('@css-inline/css-inline-wasm');
+  } catch (e) {
+    if (loadError) {
+      throw loadError;
+    }
+    throw e;
   }
-  throw new Error(`Failed to load native binding`)
 }
 
 const { inline, inlineFragment, version } = nativeBinding


### PR DESCRIPTION
Graceful loader fallback to WASM when native binding is missing — fixes #502
**What & Why**
`bindings/javascript/index.js` now tries to load `@css-inline/css-inline-wasm` if no native .node file can be resolved.
This prevents runtime crashes in two common scenarios:

1. Intel macOS (darwin-x64) – loader previously required the ARM64 binary first and aborted with MODULE_NOT_FOUND.
2. Any platform built with npm ci --omit=optional – optional native packages are skipped to slim Docker/CI images, so the loader found nothing and crashed.

With this patch the package:

- still prefers the platform-specific native binary (fastest path).
- silently falls back to WASM if the native module isn’t installed.
- honours existing logic; no API surface changes.

**Reproduction (before)**
bash
```
npm init -y
npm i @css-inline/css-inline        # installs core only, no native bindings
node -e "require('@css-inline/css-inline')"
# → Error: Cannot find module '@css-inline/css-inline-darwin-arm64'
```
**Result (after this PR)**
Same commands now output nothing (module loads) or, if you add a quick call:

bash
```
node -e "require('@css-inline/css-inline').inline('<p>hi</p>'); console.log('ok')"
# → ok
```

**Implementation details**
diff
```
if (!nativeBinding) {
-  if (loadError) throw loadError;
-  throw new Error('Failed to load native binding');
+  try {
+    nativeBinding = require('@css-inline/css-inline-wasm');
+  } catch (e) {
+    if (loadError) throw loadError;
+    throw e;
+  }
}
```
No other files touched.

**Related**

- Fixes #502 (discussion & steps to reproduce).
- Inspired by similar fallback strategy in other napi-rs projects.

Happy to add a CI matrix (`macOS-x64`, `macOS-arm64`, Linux with/without `--omit=optional`) in a follow-up PR if useful.