### PR TITLE
fix: `width`/`height` HTML attributes not derived from an element's own inline `style` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Update `selectors` to `0.38`.
 - Update `cssparser` to `0.37`.
 
+### Fixed
+
+- `width`/`height` HTML attributes not derived from an element's own inline `style` attribute. [#725](https://github.com/Stranger6667/css-inline/issues/725)
+
 ## [0.20.2] - 2026-04-02
 
 ### Fixed

--- a/bindings/c/CHANGELOG.md
+++ b/bindings/c/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Update `selectors` to `0.38`.
 - Update `cssparser` to `0.37`.
 
+### Fixed
+
+- `width`/`height` HTML attributes not derived from an element's own inline `style` attribute. [#725](https://github.com/Stranger6667/css-inline/issues/725)
+
 ## [0.20.2] - 2026-04-02
 
 ### Fixed

--- a/bindings/java/CHANGELOG.md
+++ b/bindings/java/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Update `selectors` to `0.38`.
 - Update `cssparser` to `0.37`.
 
+### Fixed
+
+- `width`/`height` HTML attributes not derived from an element's own inline `style` attribute. [#725](https://github.com/Stranger6667/css-inline/issues/725)
+
 ## [0.20.2] - 2026-04-02
 
 ### Added

--- a/bindings/javascript/CHANGELOG.md
+++ b/bindings/javascript/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Update `selectors` to `0.38`.
 - Update `cssparser` to `0.37`.
 
+### Fixed
+
+- `width`/`height` HTML attributes not derived from an element's own inline `style` attribute. [#725](https://github.com/Stranger6667/css-inline/issues/725)
+
 ## [0.20.2] - 2026-04-02
 
 ### Fixed

--- a/bindings/php/CHANGELOG.md
+++ b/bindings/php/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Update `selectors` to `0.38`.
 - Update `cssparser` to `0.37`.
 
+### Fixed
+
+- `width`/`height` HTML attributes not derived from an element's own inline `style` attribute. [#725](https://github.com/Stranger6667/css-inline/issues/725)
+
 ## [0.20.2] - 2026-04-02
 
 ### Fixed

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Update `cssparser` to `0.37`.
 - Update `PyO3` to `0.29.0`.
 
+### Fixed
+
+- `width`/`height` HTML attributes not derived from an element's own inline `style` attribute. [#725](https://github.com/Stranger6667/css-inline/issues/725)
+
 ## [0.20.2] - 2026-04-02
 
 ### Fixed

--- a/bindings/ruby/CHANGELOG.md
+++ b/bindings/ruby/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Update `selectors` to `0.38`.
 - Update `cssparser` to `0.37`.
 
+### Fixed
+
+- `width`/`height` HTML attributes not derived from an element's own inline `style` attribute. [#725](https://github.com/Stranger6667/css-inline/issues/725)
+
 ## [0.20.3] - 2026-04-02
 
 ### Changed

--- a/css-inline/src/html/serializer.rs
+++ b/css-inline/src/html/serializer.rs
@@ -119,6 +119,37 @@ fn find_style_value<'a>(styles: &'a ElementStyleMap<'_>, property: &str) -> Opti
         .map(|(_, _, value)| *value)
 }
 
+/// Find a property value in an element's inline `style` attribute (last declaration wins).
+fn find_inline_style_value<'a>(style: &'a str, property: &str) -> Option<&'a str> {
+    let mut input = cssparser::ParserInput::new(style);
+    let mut css_parser = cssparser::Parser::new(&mut input);
+    let mut declaration_parser = parser::CSSDeclarationListParser;
+    let declarations = cssparser::RuleBodyParser::new(&mut css_parser, &mut declaration_parser);
+    let mut found = None;
+    for (name, value) in declarations.flatten() {
+        if name.eq_ignore_ascii_case(property) {
+            found = Some(value);
+        }
+    }
+    found
+}
+
+/// Pick the cascade-effective value between an inline `style` declaration and a stylesheet rule.
+/// Precedence (high to low): inline `!important`, stylesheet `!important`, inline, stylesheet.
+fn effective_dimension<'a>(
+    inline: Option<&'a str>,
+    stylesheet: Option<&'a str>,
+) -> Option<&'a str> {
+    let important = |v: &str| v.trim_end().ends_with("!important");
+    if inline.is_some_and(important) {
+        inline
+    } else if stylesheet.is_some_and(important) {
+        stylesheet
+    } else {
+        inline.or(stylesheet)
+    }
+}
+
 #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
 pub(crate) fn serialize_to<W: Write>(
     document: &Document,
@@ -418,11 +449,14 @@ impl<'a, W: Write> HtmlSerializer<'a, W> {
         if let Some(ref html_name) = html_name {
             if supports_dimension_attrs(html_name) {
                 let allow_percent = is_table_element(html_name);
+                // Resolve the cascade-effective value across the inline `style` and stylesheet.
+                let style_attr = attrs.get(local_name!("style"));
                 if apply_width_attributes && !attrs.contains(local_name!("width")) {
-                    if let Some(dim) = styles
-                        .as_ref()
-                        .and_then(|s| find_style_value(s, "width"))
-                        .and_then(|v| extract_dimension_value(v, allow_percent))
+                    if let Some(dim) = effective_dimension(
+                        style_attr.and_then(|s| find_inline_style_value(s, "width")),
+                        styles.as_ref().and_then(|s| find_style_value(s, "width")),
+                    )
+                    .and_then(|v| extract_dimension_value(v, allow_percent))
                     {
                         self.writer.write_all(b" width=\"")?;
                         dim.write_to(&mut self.writer)?;
@@ -430,10 +464,11 @@ impl<'a, W: Write> HtmlSerializer<'a, W> {
                     }
                 }
                 if apply_height_attributes && !attrs.contains(local_name!("height")) {
-                    if let Some(dim) = styles
-                        .as_ref()
-                        .and_then(|s| find_style_value(s, "height"))
-                        .and_then(|v| extract_dimension_value(v, allow_percent))
+                    if let Some(dim) = effective_dimension(
+                        style_attr.and_then(|s| find_inline_style_value(s, "height")),
+                        styles.as_ref().and_then(|s| find_style_value(s, "height")),
+                    )
+                    .and_then(|v| extract_dimension_value(v, allow_percent))
                     {
                         self.writer.write_all(b" height=\"")?;
                         dim.write_to(&mut self.writer)?;

--- a/css-inline/tests/test_inlining.rs
+++ b/css-inline/tests/test_inlining.rs
@@ -2075,16 +2075,48 @@ fn apply_width_specificity() {
 
 #[test]
 fn apply_width_from_inline_style() {
-    // Dimension attributes are extracted from stylesheet rules, not pre-existing inline styles.
-    // The final style attribute will contain the merged/overridden value (inline wins),
-    // but the dimension attribute is set from the stylesheet rule.
+    // Inline `style` wins over stylesheet rules (CSS cascade), and the dimension attribute
+    // reflects that effective value.
     let inliner = CSSInliner::options().apply_width_attributes(true).build();
     let html = r#"<html><head><style>img { width: 50px; }</style></head><body><img style="width: 100px;"></body></html>"#;
     let result = inliner.inline(html).unwrap();
-    // Stylesheet value is used for the attribute
-    assert!(result.contains(r#"width="50""#));
-    // Inline style wins in the style attribute (100px overrides 50px)
+    // Effective (inline) value is used for the attribute
+    assert!(result.contains(r#"width="100""#));
     assert!(result.contains(r#"style="width: 100px""#));
+}
+
+#[test]
+fn apply_dimension_from_inline_style_only() {
+    // Dimensions present only in the element's inline `style` attribute (no stylesheet rule)
+    // still produce width/height attributes. See GH-725.
+    let inliner = CSSInliner::options()
+        .apply_width_attributes(true)
+        .apply_height_attributes(true)
+        .build();
+    let html =
+        r#"<html><body><img src="t.jpg" style="width: 600px; height: 400px;"></body></html>"#;
+    let result = inliner.inline(html).unwrap();
+    assert!(result.contains(r#"width="600""#));
+    assert!(result.contains(r#"height="400""#));
+}
+
+#[test]
+fn apply_width_stylesheet_important_beats_inline() {
+    // Cascade: stylesheet `!important` beats a normal inline declaration, so the
+    // attribute reflects the stylesheet value (not the inline one).
+    let inliner = CSSInliner::options().apply_width_attributes(true).build();
+    let html = r#"<html><head><style>img { width: 50px !important; }</style></head><body><img style="width: 100px;"></body></html>"#;
+    let result = inliner.inline(html).unwrap();
+    assert!(result.contains(r#"width="50""#));
+}
+
+#[test]
+fn apply_width_inline_important_beats_stylesheet_important() {
+    // Inline `!important` wins over stylesheet `!important`.
+    let inliner = CSSInliner::options().apply_width_attributes(true).build();
+    let html = r#"<html><head><style>img { width: 50px !important; }</style></head><body><img style="width: 100px !important;"></body></html>"#;
+    let result = inliner.inline(html).unwrap();
+    assert!(result.contains(r#"width="100""#));
 }
 
 #[test]


### PR DESCRIPTION
Fixes #725 