### PR TITLE
Preserve block-less at-rules when keep_at_rules is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- With `keep_at_rules` enabled, at-rules without a block (e.g. `@import`) lost their prelude and terminator, fusing with the following rule (`@import@media ...`) and producing a stylesheet browsers reject entirely.
+
 ## [0.21.0] - 2026-06-16
 
 ### Changed

--- a/bindings/c/CHANGELOG.md
+++ b/bindings/c/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- With `keep_at_rules` enabled, at-rules without a block (e.g. `@import`) lost their prelude and terminator, fusing with the following rule (`@import@media ...`) and producing a stylesheet browsers reject entirely.
+
 ## [0.21.0] - 2026-06-16
 
 ### Changed

--- a/bindings/java/CHANGELOG.md
+++ b/bindings/java/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- With `keepAtRules` enabled, at-rules without a block (e.g. `@import`) lost their prelude and terminator, fusing with the following rule (`@import@media ...`) and producing a stylesheet browsers reject entirely.
+
 ## [0.21.0] - 2026-06-16
 
 ### Changed

--- a/bindings/javascript/CHANGELOG.md
+++ b/bindings/javascript/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- With `keepAtRules` enabled, at-rules without a block (e.g. `@import`) lost their prelude and terminator, fusing with the following rule (`@import@media ...`) and producing a stylesheet browsers reject entirely.
+
 ## [0.21.0] - 2026-06-16
 
 ### Changed

--- a/bindings/javascript/wasm/index.html
+++ b/bindings/javascript/wasm/index.html
@@ -209,8 +209,7 @@
   <body>
     <h1>Big Text</h1>
   </body>
-</html></textarea
-              >
+</html></textarea>
             </div>
             <div
               class="mt-auto border-t border-gray-100 pt-4 sm:flex sm:items-center sm:justify-between"

--- a/bindings/php/CHANGELOG.md
+++ b/bindings/php/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- With `keepAtRules` enabled, at-rules without a block (e.g. `@import`) lost their prelude and terminator, fusing with the following rule (`@import@media ...`) and producing a stylesheet browsers reject entirely.
+
 ## [0.21.0] - 2026-06-16
 
 ### Changed

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- With `keep_at_rules` enabled, at-rules without a block (e.g. `@import`) lost their prelude and terminator, fusing with the following rule (`@import@media ...`) and producing a stylesheet browsers reject entirely.
+
 ## [0.21.0] - 2026-06-16
 
 ### Removed

--- a/bindings/ruby/CHANGELOG.md
+++ b/bindings/ruby/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- With `keep_at_rules` enabled, at-rules without a block (e.g. `@import`) lost their prelude and terminator, fusing with the following rule (`@import@media ...`) and producing a stylesheet browsers reject entirely.
+
 ## [0.21.0] - 2026-06-16
 
 ### Changed

--- a/css-inline/src/html/element.rs
+++ b/css-inline/src/html/element.rs
@@ -66,31 +66,25 @@ impl<'a> Element<'a> {
     fn previous_sibling_element(&self) -> Option<Element<'a>> {
         let mut node = &self.document[self.node_id];
         loop {
-            if let Some(previous_sibling_id) = node.previous_sibling {
-                let previous_sibling = &self.document[previous_sibling_id];
-                if let NodeData::Element { element, .. } = &previous_sibling.data {
-                    return Some(Element::new(self.document, previous_sibling_id, element));
-                }
-                node = previous_sibling;
-            } else {
-                // Node has no previous sibling at all
-                return None;
+            // Returns `None` once the node has no previous sibling at all
+            let previous_sibling_id = node.previous_sibling?;
+            let previous_sibling = &self.document[previous_sibling_id];
+            if let NodeData::Element { element, .. } = &previous_sibling.data {
+                return Some(Element::new(self.document, previous_sibling_id, element));
             }
+            node = previous_sibling;
         }
     }
     fn next_sibling_element(&self) -> Option<Element<'a>> {
         let mut node = &self.document[self.node_id];
         loop {
-            if let Some(next_sibling_id) = node.next_sibling {
-                let next_sibling = &self.document[next_sibling_id];
-                if let NodeData::Element { element, .. } = &next_sibling.data {
-                    return Some(Element::new(self.document, next_sibling_id, element));
-                }
-                node = next_sibling;
-            } else {
-                // Node has no next sibling at all
-                return None;
+            // Returns `None` once the node has no next sibling at all
+            let next_sibling_id = node.next_sibling?;
+            let next_sibling = &self.document[next_sibling_id];
+            if let NodeData::Element { element, .. } = &next_sibling.data {
+                return Some(Element::new(self.document, next_sibling_id, element));
             }
+            node = next_sibling;
         }
     }
     // NOTE: For large documents, it is called in a hot loop.

--- a/css-inline/src/html/selectors/attr_value.rs
+++ b/css-inline/src/html/selectors/attr_value.rs
@@ -11,7 +11,7 @@ impl ToCss for AttrValue {
     where
         W: Write,
     {
-        write!(cssparser::CssStringWriter::new(dest), "{}", &self.0)
+        write!(cssparser::CssStringWriter::new(dest), "{}", self.0)
     }
 }
 

--- a/css-inline/src/parser.rs
+++ b/css-inline/src/parser.rs
@@ -161,6 +161,21 @@ impl<'i> cssparser::AtRuleParser<'i> for AtRuleFilteringParser<'_, 'i, '_> {
         self.at_rules.push(' ');
         Ok((prelude, (start, self.at_rules.len())))
     }
+
+    fn rule_without_block(
+        &mut self,
+        prelude: Self::Prelude,
+        _start: &ParserState,
+    ) -> Result<Self::AtRule, ()> {
+        // `parse_prelude` has already written `@` + the rule name; without this
+        // the name would fuse with the following rule (e.g. `@import@media ...`),
+        // producing a stylesheet browsers reject entirely.
+        let start = self.at_rules.len();
+        self.at_rules.push_str(prelude);
+        self.at_rules.push(';');
+        self.at_rules.push(' ');
+        Ok((prelude, (start, self.at_rules.len())))
+    }
 }
 
 fn parse_declarations_into<'i>(

--- a/css-inline/tests/test_inlining.rs
+++ b/css-inline/tests/test_inlining.rs
@@ -780,6 +780,44 @@ fn keep_multiple_at_rules() {
 }
 
 #[test]
+fn keep_at_rules_without_block() {
+    // At-rules terminated by a semicolon instead of a block (e.g. `@import`)
+    // must keep their prelude and terminator; otherwise the bare `@import`
+    // fuses with the following rule and browsers discard the whole sheet.
+    let html = r#"
+<html>
+<head>
+<style>
+@import url("print.css");
+@media (max-width: 600px) { h1 { font-size: 18px; } }
+</style>
+</head>
+<body>
+<h1>Test</h1>
+</body>
+</html>
+    "#;
+
+    let options = InlineOptions {
+        keep_at_rules: true,
+        ..Default::default()
+    };
+    let inliner = CSSInliner::new(options);
+    let result = inliner.inline(html).unwrap();
+    assert_eq!(
+        result,
+        r#"<html><head><style>@import url("print.css"); @media (max-width: 600px) { h1 { font-size: 18px; } } </style>
+
+</head>
+<body>
+<h1>Test</h1>
+
+
+    </body></html>"#
+    )
+}
+
+#[test]
 fn extra_css() {
     let html = html!("h1 {background-color: blue;}", "<h1>Hello world!</h1>");
     let options = InlineOptions {

--- a/profiler/src/main.rs
+++ b/profiler/src/main.rs
@@ -39,7 +39,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             output.clear();
         }
     } else {
-        panic!("Can not find benchmark: {}", &args.benchmark)
+        panic!("Can not find benchmark: {}", args.benchmark)
     }
 
     Ok(())


### PR DESCRIPTION
## Problem

With `keep_at_rules: true`, an at-rule terminated by a semicolon instead of a block — `@import` being the common case — loses its prelude and terminator. `AtRuleFilteringParser` writes `@` + the rule name in `parse_prelude` and appends the prelude/body in `parse_block`, but never implements `rule_without_block` (whose default rejects the rule), so the already-written bare `@import` fuses with the following rule:

```css
/* input */
@import url("print.css");
@media (max-width: 600px) { h1 { font-size: 18px; } }

/* output */
@import@media (max-width: 600px) { h1 { font-size: 18px; } }
```

Browsers treat the fused text as one invalid rule and discard it — in Chromium the resulting `<style>` sheet parses to `cssRules.length === 0` — so a single `@import` silently disables every at-rule the option was meant to keep. We hit this inlining MJML email output, where the responsive `@media` block stopped applying on mobile clients.

## Fix

Implement `rule_without_block` to emit the prelude and a terminating semicolon, mirroring how `parse_block` emits blocked at-rules:

```css
@import url("print.css"); @media (max-width: 600px) { h1 { font-size: 18px; } }
```

Includes a regression test (fails on master with the fused output above) and a changelog entry. Full suite passes locally apart from the four tests that need the `127.0.0.1:1234` stylesheet server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)